### PR TITLE
Travis builds on non-container infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: android
+sudo: true
 android:
   components:
     # Uncomment the lines below if you want to

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,3 +23,4 @@ script: gradle build lint test
 
 after_failure:
 - cat app/build/outputs/lint-results.xml
+- cat app/build/reports/tests/debug/index.html

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,6 @@ android:
     # Additional components
     - extra
 
-    # Specify at least one system image,
-    # if you need to run emulator(s) during your tests
-    - sys-img-x86-android-17
-
 script: gradle build lint test
 
 after_failure:


### PR DESCRIPTION
There are now issues with the travis-ci builds, where unit tests will fail before actually running:
```
    Downloading: org/robolectric/robolectric-resources/3.0/robolectric-resources-3.0.jar from repository sonatype at https://oss.sonatype.org/content/groups/public/
    Transferring 146K from sonatype
:app:testDebugUnitTest FAILED
:app:testDebugUnitTest (Thread[main,5,main]) completed. Took 33.921 secs.
FAILURE: Build failed with an exception.
* What went wrong:
Execution failed for task ':app:testDebugUnitTest'.
> Process 'Gradle Test Executor 1' finished with non-zero exit value 137
```
By forcing builds to occur on non-container infrastructure, it is hoped that
whatever is the issue (memory exhaustion, etc) is avoided.
