### PR TITLE
Only initialize spinner if it is not yet initialized

### DIFF
--- a/app/src/main/java/protect/budgetwatch/TransactionViewActivity.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionViewActivity.java
@@ -132,8 +132,13 @@ public class TransactionViewActivity extends AppCompatActivity
         final Spinner budgetSpinner = (Spinner) findViewById(R.id.budgetSpinner);
         DBHelper db = new DBHelper(TransactionViewActivity.this);
         List<String> budgetNames = db.getBudgetNames();
-        ArrayAdapter<String> budgets = new ArrayAdapter<>(this, R.layout.spinner_textview, budgetNames);
-        budgetSpinner.setAdapter(budgets);
+
+        // Add budget items to spinner if it has not been initialized yet
+        if(budgetSpinner.getCount() == 0)
+        {
+            ArrayAdapter<String> budgets = new ArrayAdapter<>(this, R.layout.spinner_textview, budgetNames);
+            budgetSpinner.setAdapter(budgets);
+        }
 
         final EditText nameField = (EditText) findViewById(R.id.name);
         final EditText accountField = (EditText) findViewById(R.id.account);


### PR DESCRIPTION
Previously, if one when adding a new transaction were to select
a budget option and capture a receipt the budget option was
reset. This is because the budget spinner was reset. To prevent
this, only reset the budget spinner if it currently is empty.