### PR TITLE
Edit Budget/Transaction on long click

### DIFF
--- a/app/src/main/java/protect/budgetwatch/BudgetActivity.java
+++ b/app/src/main/java/protect/budgetwatch/BudgetActivity.java
@@ -8,7 +8,9 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.ContextMenu;
 import android.view.Menu;
+import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.widget.AdapterView;
@@ -89,21 +91,41 @@ public class BudgetActivity extends AppCompatActivity
         final BudgetAdapter budgetListAdapter = new BudgetAdapter(this, budgets);
         budgetList.setAdapter(budgetListAdapter);
 
-        budgetList.setOnItemClickListener(new AdapterView.OnItemClickListener()
-        {
-            @Override
-            public void onItemClick(AdapterView<?> parent, View view, int position, long id)
-            {
-                Budget budget = (Budget)parent.getItemAtPosition(position);
+        registerForContextMenu(budgetList);
+    }
 
-                Intent i = new Intent(getApplicationContext(), BudgetViewActivity.class);
-                Bundle bundle = new Bundle();
-                bundle.putString("id", budget.name);
-                bundle.putBoolean("view", true);
-                i.putExtras(bundle);
-                startActivity(i);
-            }
-        });
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo)
+    {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        if (v.getId()==R.id.list)
+        {
+            MenuInflater inflater = getMenuInflater();
+            inflater.inflate(R.menu.edit_menu, menu);
+        }
+    }
+
+    @Override
+    public boolean onContextItemSelected(MenuItem item)
+    {
+        AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo) item.getMenuInfo();
+        ListView listView = (ListView) findViewById(R.id.list);
+
+        Budget budget = (Budget)listView.getItemAtPosition(info.position);
+
+        if(budget != null && item.getItemId() == R.id.action_edit)
+        {
+            Intent i = new Intent(getApplicationContext(), BudgetViewActivity.class);
+            Bundle bundle = new Bundle();
+            bundle.putString("id", budget.name);
+            bundle.putBoolean("view", true);
+            i.putExtras(bundle);
+            startActivity(i);
+
+            return true;
+        }
+
+        return super.onContextItemSelected(item);
     }
 
     @Override

--- a/app/src/main/java/protect/budgetwatch/TransactionExpenseFragment.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionExpenseFragment.java
@@ -4,10 +4,15 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.view.ContextMenu;
+import android.view.ContextMenu.ContextMenuInfo;
 import android.view.LayoutInflater;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
+import android.widget.AdapterView.AdapterContextMenuInfo;
 import android.widget.ListView;
 import android.widget.TextView;
 
@@ -37,6 +42,8 @@ public class TransactionExpenseFragment extends Fragment
         final TransactionCursorAdapter adapter = new TransactionCursorAdapter(getContext(), expenseCursor);
         listView.setAdapter(adapter);
 
+        registerForContextMenu(listView);
+
         listView.setOnItemClickListener(new AdapterView.OnItemClickListener()
         {
             @Override
@@ -56,5 +63,44 @@ public class TransactionExpenseFragment extends Fragment
         });
 
         return layout;
+    }
+
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo)
+    {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        if (v.getId()==R.id.list)
+        {
+            MenuInflater inflater = getActivity().getMenuInflater();
+            inflater.inflate(R.menu.edit_menu, menu);
+        }
+    }
+
+    @Override
+    public boolean onContextItemSelected(MenuItem item)
+    {
+        AdapterContextMenuInfo info = (AdapterContextMenuInfo) item.getMenuInfo();
+        ListView listView = (ListView) getActivity().findViewById(R.id.list);
+        Cursor selected = (Cursor)listView.getItemAtPosition(info.position);
+
+        if(selected != null)
+        {
+            Transaction transaction = Transaction.toTransaction(selected);
+
+            if(item.getItemId() == R.id.action_edit)
+            {
+                Intent i = new Intent(getActivity(), TransactionViewActivity.class);
+                final Bundle b = new Bundle();
+                b.putInt("id", transaction.id);
+                b.putInt("type", DBHelper.TransactionDbIds.EXPENSE);
+                b.putBoolean("update", true);
+                i.putExtras(b);
+                startActivity(i);
+
+                return true;
+            }
+        }
+
+        return super.onContextItemSelected(item);
     }
 }

--- a/app/src/main/java/protect/budgetwatch/TransactionRevenueFragment.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionRevenueFragment.java
@@ -4,7 +4,10 @@ import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
+import android.view.ContextMenu;
 import android.view.LayoutInflater;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.AdapterView;
@@ -38,6 +41,8 @@ public class TransactionRevenueFragment extends Fragment
         final TransactionCursorAdapter adapter = new TransactionCursorAdapter(getContext(), expenseCursor);
         listView.setAdapter(adapter);
 
+        registerForContextMenu(listView);
+
         listView.setOnItemClickListener(new AdapterView.OnItemClickListener()
         {
             @Override
@@ -57,5 +62,44 @@ public class TransactionRevenueFragment extends Fragment
         });
 
         return layout;
+    }
+
+    @Override
+    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenu.ContextMenuInfo menuInfo)
+    {
+        super.onCreateContextMenu(menu, v, menuInfo);
+        if (v.getId()==R.id.list)
+        {
+            MenuInflater inflater = getActivity().getMenuInflater();
+            inflater.inflate(R.menu.edit_menu, menu);
+        }
+    }
+
+    @Override
+    public boolean onContextItemSelected(MenuItem item)
+    {
+        AdapterView.AdapterContextMenuInfo info = (AdapterView.AdapterContextMenuInfo) item.getMenuInfo();
+        ListView listView = (ListView) getActivity().findViewById(R.id.list);
+        Cursor selected = (Cursor)listView.getItemAtPosition(info.position);
+
+        if(selected != null)
+        {
+            Transaction transaction = Transaction.toTransaction(selected);
+
+            if(item.getItemId() == R.id.action_edit)
+            {
+                Intent i = new Intent(getActivity(), TransactionViewActivity.class);
+                final Bundle b = new Bundle();
+                b.putInt("id", transaction.id);
+                b.putInt("type", DBHelper.TransactionDbIds.REVENUE);
+                b.putBoolean("update", true);
+                i.putExtras(b);
+                startActivity(i);
+
+                return true;
+            }
+        }
+
+        return super.onContextItemSelected(item);
     }
 }


### PR DESCRIPTION
Feedback was received on the expected workflow of deleting or
editing a Budget or Transaction. It turns out the expectation
is to long click an item to reveal non-typical options. Clicking
on an object should reveal the most common option.

To this end, a long click on a Budget or Transaction will now bring
up a context menu, showing an edit option. Clicking on a Transaction
will still display it, but clicking on a Budget will no longer
do anything.