### PR TITLE
Reduce min SDK version to 13

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -12,7 +12,7 @@ android {
 
     defaultConfig {
         applicationId "protect.budgetwatch"
-        minSdkVersion 17
+        minSdkVersion 13
         targetSdkVersion 23
         versionCode 5
         versionName "0.5"


### PR DESCRIPTION
The selection of SDK 17 was arbitrarily based on the version
available on my device at the time. As no APIs are being used
at that level, a lower SDK version can be targeted.

All the APIs currently used by the application were available
in SDK 13+. Moving the min SDK version to 13.