### PR TITLE
Transaction view resets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -32,6 +32,7 @@
             android:name=".BudgetViewActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.NoActionBar"
+            android:windowSoftInputMode="stateHidden"
             android:parentActivityName=".BudgetActivity"/>
         <activity
             android:name=".TransactionActivity"
@@ -44,6 +45,7 @@
             android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.NoActionBar"
             android:launchMode="singleTop"
+            android:windowSoftInputMode="stateHidden"
             android:parentActivityName=".TransactionActivity"/>
         <activity
             android:name=".ImportExportActivity"

--- a/app/src/main/java/protect/budgetwatch/DBHelper.java
+++ b/app/src/main/java/protect/budgetwatch/DBHelper.java
@@ -2,6 +2,7 @@ package protect.budgetwatch;
 
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.Intent;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
@@ -50,9 +51,20 @@ public class DBHelper extends SQLiteOpenHelper
         public static final int REVENUE = 2;
     }
 
+    private Context _context;
+
     public DBHelper(Context context)
     {
         super(context, DATABASE_NAME, null, DATABASE_VERSION);
+        _context = context;
+    }
+
+    /**
+     * Send a notification that the transaction database has changed
+     */
+    private void sendChangeNotification()
+    {
+        _context.sendBroadcast(new Intent(TransactionDatabaseChangedReceiver.ACTION_DATABASE_CHANGED));
     }
 
     @Override
@@ -361,6 +373,11 @@ public class DBHelper extends SQLiteOpenHelper
         long newId = db.insert(TransactionDbIds.TABLE, null, contentValues);
         db.close();
 
+        if(newId != -1)
+        {
+            sendChangeNotification();
+        }
+
         return (newId != -1);
     }
 
@@ -389,6 +406,12 @@ public class DBHelper extends SQLiteOpenHelper
         contentValues.put(TransactionDbIds.RECEIPT, receipt);
 
         long newId = writableDb.insert(TransactionDbIds.TABLE, null, contentValues);
+
+        if(newId != -1)
+        {
+            sendChangeNotification();
+        }
+
         return (newId != -1);
     }
 
@@ -421,6 +444,11 @@ public class DBHelper extends SQLiteOpenHelper
                 TransactionDbIds.NAME + "=?",
                 new String[]{Integer.toString(id)});
         db.close();
+
+        if(rowsUpdated == 1)
+        {
+            sendChangeNotification();
+        }
 
         return (rowsUpdated == 1);
     }
@@ -498,6 +526,12 @@ public class DBHelper extends SQLiteOpenHelper
                 TransactionDbIds.NAME + " = ? ",
                 new String[]{Integer.toString(id)});
         db.close();
+
+        if(rowsDeleted == 1)
+        {
+            sendChangeNotification();
+        }
+
         return (rowsDeleted == 1);
     }
 

--- a/app/src/main/java/protect/budgetwatch/TransactionDatabaseChangedReceiver.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionDatabaseChangedReceiver.java
@@ -1,0 +1,33 @@
+package protect.budgetwatch;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+
+/**
+ * This Broadcast Receiver helps one determine if the transactions
+ * database has changed since the receiver was created or was
+ * last reset.
+ */
+public class TransactionDatabaseChangedReceiver extends BroadcastReceiver
+{
+    public static final String ACTION_DATABASE_CHANGED = "protect.budgetwatch.TRANSACTION_DATABASE_CHANGED";
+
+    private boolean _hasChanged = false;
+
+    @Override
+    public void onReceive(Context context, Intent intent)
+    {
+        _hasChanged = true;
+    }
+
+    public boolean hasChanged()
+    {
+        return _hasChanged;
+    }
+
+    public void reset()
+    {
+        _hasChanged = false;
+    }
+}

--- a/app/src/main/java/protect/budgetwatch/TransactionExpenseWidget.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionExpenseWidget.java
@@ -20,6 +20,7 @@ public class TransactionExpenseWidget extends AppWidgetProvider
         Bundle extras = new Bundle();
         extras.putInt("type", DBHelper.TransactionDbIds.EXPENSE);
         intent.putExtras(extras);
+        intent.setFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
         PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
         remoteView.setOnClickPendingIntent(R.id.addTransaction, pendingIntent);
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -1,8 +1,4 @@
 <resources>
-    <!-- Default screen margins, per the Android Design guidelines. -->
-    <dimen name="activity_horizontal_margin">16dp</dimen>
-    <dimen name="activity_vertical_margin">16dp</dimen>
-
     <dimen name="no_data_textSize">16sp</dimen>
     <dimen name="no_data_padding">22dp</dimen>
 

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.0.0'
+        classpath 'com.android.tools.build:gradle:2.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Only update the transaction list when the transaction activity is resumed if the database has been updated. This also include a few other smaller fixes and improvements.