### PR TITLE
Remove usage of parentActivityName attribute

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,42 +26,35 @@
         <activity
             android:name=".BudgetActivity"
             android:label="@string/budgetsTitle"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:parentActivityName=".MainActivity"/>
+            android:theme="@style/AppTheme.NoActionBar"/>
         <activity
             android:name=".BudgetViewActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden"
-            android:parentActivityName=".BudgetActivity"/>
+            android:windowSoftInputMode="stateHidden"/>
         <activity
             android:name=".TransactionActivity"
             android:label="@string/transactionsTitle"
             android:theme="@style/AppTheme.NoActionBar"
-            android:launchMode="singleTop"
-            android:parentActivityName=".MainActivity"/>
+            android:launchMode="singleTop"/>
         <activity
             android:name=".TransactionViewActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.NoActionBar"
             android:launchMode="singleTop"
-            android:windowSoftInputMode="stateHidden"
-            android:parentActivityName=".TransactionActivity"/>
+            android:windowSoftInputMode="stateHidden"/>
         <activity
             android:name=".ImportExportActivity"
             android:label="@string/importExportTitle"
             android:configChanges="orientation|screenSize"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:parentActivityName=".MainActivity"/>
+            android:theme="@style/AppTheme.NoActionBar"/>
         <activity
             android:name=".ReceiptViewActivity"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:parentActivityName=".TransactionViewActivity"/>
+            android:theme="@style/AppTheme.NoActionBar"/>
         <activity
             android:name=".SettingsActivity"
             android:label="@string/settings"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:parentActivityName=".MainActivity"/>
+            android:theme="@style/AppTheme.NoActionBar"/>
         <receiver android:label="@string/app_name" android:name="TransactionExpenseWidget">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>

--- a/app/src/main/java/protect/budgetwatch/BudgetActivity.java
+++ b/app/src/main/java/protect/budgetwatch/BudgetActivity.java
@@ -255,6 +255,12 @@ public class BudgetActivity extends AppCompatActivity
             builder.show();
         }
 
+        if(id == android.R.id.home)
+        {
+            finish();
+            return true;
+        }
+
         return super.onOptionsItemSelected(item);
     }
 

--- a/app/src/main/java/protect/budgetwatch/BudgetActivity.java
+++ b/app/src/main/java/protect/budgetwatch/BudgetActivity.java
@@ -253,6 +253,7 @@ public class BudgetActivity extends AppCompatActivity
             });
 
             builder.show();
+            return true;
         }
 
         if(id == android.R.id.home)

--- a/app/src/main/java/protect/budgetwatch/BudgetViewActivity.java
+++ b/app/src/main/java/protect/budgetwatch/BudgetViewActivity.java
@@ -208,6 +208,10 @@ public class BudgetViewActivity extends AppCompatActivity
                 dialog.show();
 
                 return true;
+
+            case android.R.id.home:
+                finish();
+                return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/main/java/protect/budgetwatch/ImportExportActivity.java
+++ b/app/src/main/java/protect/budgetwatch/ImportExportActivity.java
@@ -5,6 +5,7 @@ import android.os.Bundle;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 import android.view.View;
 import android.widget.Button;
 
@@ -60,5 +61,19 @@ public class ImportExportActivity extends AppCompatActivity
             importExporter.cancel(true);
         }
         super.onDestroy();
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
+        int id = item.getItemId();
+
+        if(id == android.R.id.home)
+        {
+            finish();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/protect/budgetwatch/ReceiptViewActivity.java
+++ b/app/src/main/java/protect/budgetwatch/ReceiptViewActivity.java
@@ -5,7 +5,6 @@ import android.graphics.BitmapFactory;
 import android.graphics.Point;
 import android.net.Uri;
 import android.os.Bundle;
-import android.support.v4.app.NavUtils;
 import android.support.v4.view.MenuItemCompat;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
@@ -97,13 +96,14 @@ public class ReceiptViewActivity  extends AppCompatActivity
     @Override
     public boolean onOptionsItemSelected(MenuItem item)
     {
-        switch (item.getItemId())
+        int id = item.getItemId();
+
+        if(id == android.R.id.home)
         {
-            // Respond to the action bar's Up/Home button
-            case android.R.id.home:
-                NavUtils.navigateUpFromSameTask(this);
-                return true;
+            finish();
+            return true;
         }
+
         return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/protect/budgetwatch/SettingsActivity.java
+++ b/app/src/main/java/protect/budgetwatch/SettingsActivity.java
@@ -5,6 +5,7 @@ import android.preference.PreferenceFragment;
 import android.support.v7.app.ActionBar;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.view.MenuItem;
 
 public class SettingsActivity extends AppCompatActivity
 {
@@ -37,5 +38,19 @@ public class SettingsActivity extends AppCompatActivity
             // Load the preferences from an XML resource
             addPreferencesFromResource(R.xml.settings);
         }
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item)
+    {
+        int id = item.getItemId();
+
+        if(id == android.R.id.home)
+        {
+            finish();
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
     }
 }

--- a/app/src/main/java/protect/budgetwatch/TransactionActivity.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionActivity.java
@@ -144,6 +144,7 @@ public class TransactionActivity extends AppCompatActivity
             });
 
             builder.show();
+            return true;
         }
 
         if(id == android.R.id.home)

--- a/app/src/main/java/protect/budgetwatch/TransactionActivity.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionActivity.java
@@ -146,6 +146,12 @@ public class TransactionActivity extends AppCompatActivity
             builder.show();
         }
 
+        if(id == android.R.id.home)
+        {
+            finish();
+            return true;
+        }
+
         return super.onOptionsItemSelected(item);
     }
 

--- a/app/src/main/java/protect/budgetwatch/TransactionViewActivity.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionViewActivity.java
@@ -515,6 +515,10 @@ public class TransactionViewActivity extends AppCompatActivity
                 dialog.show();
 
                 return true;
+
+            case android.R.id.home:
+                finish();
+                return true;
         }
 
         return super.onOptionsItemSelected(item);

--- a/app/src/test/java/protect/budgetwatch/BudgetActivityTest.java
+++ b/app/src/test/java/protect/budgetwatch/BudgetActivityTest.java
@@ -71,6 +71,15 @@ public class BudgetActivityTest
     }
 
     @Test
+    public void clickBackFinishes()
+    {
+        final Activity activity = Robolectric.setupActivity(BudgetActivity.class);
+
+        shadowOf(activity).clickMenuItem(android.R.id.home);
+        assertTrue(shadowOf(activity).isFinishing());
+    }
+
+    @Test
     public void addOneBudget()
     {
         ActivityController activityController = Robolectric.buildActivity(BudgetActivity.class).create();

--- a/app/src/test/java/protect/budgetwatch/BudgetViewActivityTest.java
+++ b/app/src/test/java/protect/budgetwatch/BudgetViewActivityTest.java
@@ -1,0 +1,26 @@
+package protect.budgetwatch;
+
+import android.app.Activity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 17)
+public class BudgetViewActivityTest
+{
+    @Test
+    public void clickBackFinishes()
+    {
+        final Activity activity = Robolectric.setupActivity(BudgetViewActivity.class);
+
+        shadowOf(activity).clickMenuItem(android.R.id.home);
+        assertTrue(shadowOf(activity).isFinishing());
+    }
+}

--- a/app/src/test/java/protect/budgetwatch/ImportExportTest.java
+++ b/app/src/test/java/protect/budgetwatch/ImportExportTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
 
 @RunWith(RobolectricGradleTestRunner.class)
 @Config(constants = BuildConfig.class, sdk = 17)
@@ -455,5 +456,12 @@ public class ImportExportTest
             // Clear the database for the next format under test
             clearDatabase();
         }
+    }
+
+    @Test
+    public void clickBackFinishes()
+    {
+        shadowOf(activity).clickMenuItem(android.R.id.home);
+        assertTrue(shadowOf(activity).isFinishing());
     }
 }

--- a/app/src/test/java/protect/budgetwatch/ReceiptViewActivityTest.java
+++ b/app/src/test/java/protect/budgetwatch/ReceiptViewActivityTest.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.webkit.WebView;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.Robolectric;
@@ -22,16 +23,23 @@ import static org.robolectric.Shadows.shadowOf;
 @Config(constants = BuildConfig.class, sdk = 17)
 public class ReceiptViewActivityTest
 {
-    @Test
-    public void LoadReceipt()
+    private ActivityController activityController;
+
+    @Before
+    public void setUp()
     {
         Intent intent = new Intent();
         final Bundle bundle = new Bundle();
         bundle.putString("receipt", "receipt");
         intent.putExtras(bundle);
 
-        ActivityController activityController =  Robolectric.buildActivity(
-            ReceiptViewActivity.class).withIntent(intent).create();
+        activityController = Robolectric.buildActivity(
+                ReceiptViewActivity.class).withIntent(intent).create();
+    }
+
+    @Test
+    public void LoadReceipt()
+    {
         activityController.start();
         activityController.resume();
 

--- a/app/src/test/java/protect/budgetwatch/SettingsActivityTest.java
+++ b/app/src/test/java/protect/budgetwatch/SettingsActivityTest.java
@@ -1,0 +1,26 @@
+package protect.budgetwatch;
+
+import android.app.Activity;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 17)
+public class SettingsActivityTest
+{
+    @Test
+    public void clickBackFinishes()
+    {
+        final Activity activity = Robolectric.setupActivity(SettingsActivity.class);
+
+        shadowOf(activity).clickMenuItem(android.R.id.home);
+        assertTrue(shadowOf(activity).isFinishing());
+    }
+}

--- a/app/src/test/java/protect/budgetwatch/TransactionActivityTest.java
+++ b/app/src/test/java/protect/budgetwatch/TransactionActivityTest.java
@@ -99,4 +99,13 @@ public class TransactionActivityTest
         assertEquals("Add", menu.findItem(R.id.action_add).getTitle().toString());
         assertEquals("Purge Old Receipts", menu.findItem(R.id.action_purge_receipts).getTitle().toString());
     }
+
+    @Test
+    public void clickBackFinishes()
+    {
+        final Activity activity = Robolectric.setupActivity(TransactionActivity.class);
+
+        shadowOf(activity).clickMenuItem(android.R.id.home);
+        assertTrue(shadowOf(activity).isFinishing());
+    }
 }

--- a/app/src/test/java/protect/budgetwatch/TransactionViewActivityTest.java
+++ b/app/src/test/java/protect/budgetwatch/TransactionViewActivityTest.java
@@ -700,6 +700,16 @@ public class TransactionViewActivityTest
     }
 
     @Test
+    public void clickBackFinishes()
+    {
+        ActivityController activityController = setupActivity("budget", "", false, true);
+        Activity activity = (Activity)activityController.get();
+
+        shadowOf(activity).clickMenuItem(android.R.id.home);
+        assertTrue(shadowOf(activity).isFinishing());
+    }
+
+    @Test
     public void startAsViewCheckActionBar() throws Exception
     {
         ActivityController activityController = setupActivity("budget", "", true, false);


### PR DESCRIPTION
In all cases the normal flow of activities onto the stack is the
expected order; there is no need to force a parent activity.
In the case where a budget is clicked, bringing up a transaction
view filtered by the budget, clicking 'back' resulted in going
back to the main view. This was not expected. Removing the
parentActivityName attribute resolves this.