### PR TITLE
Import export improvements

### DIFF
--- a/app/src/main/java/protect/budgetwatch/DataFormat.java
+++ b/app/src/main/java/protect/budgetwatch/DataFormat.java
@@ -5,4 +5,13 @@ public enum DataFormat
     CSV,
     ZIP,
     ;
+
+    /**
+     * Returns the file extension name for this data format.
+     * @return
+     */
+    public String extension()
+    {
+        return this.name().toLowerCase();
+    }
 }

--- a/app/src/main/java/protect/budgetwatch/ImportExportActivity.java
+++ b/app/src/main/java/protect/budgetwatch/ImportExportActivity.java
@@ -1,19 +1,33 @@
 package protect.budgetwatch;
 
+import android.Manifest;
+import android.content.ActivityNotFoundException;
+import android.content.Context;
+import android.content.DialogInterface;
+import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Bundle;
+import android.os.Environment;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.support.v7.app.ActionBar;
+import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
+import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
-import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.Spinner;
-import android.widget.TextView;
+import android.widget.Toast;
+
 import com.google.common.collect.ImmutableMap;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -22,8 +36,14 @@ public class ImportExportActivity extends AppCompatActivity
 {
     private static final String TAG = "BudgetWatch";
 
-    ImportExportTask importExporter;
+    private static final int PERMISSIONS_EXTERNAL_STORAGE = 1;
+    private static final int CHOOSE_EXPORT_FILE = 2;
+
+    private ImportExportTask importExporter;
     private Map<String, DataFormat> _fileFormatMap;
+
+    private final File sdcardDir = Environment.getExternalStorageDirectory();
+    private final String exportFilename = "BudgetWatch";
 
     @Override
     protected void onCreate(Bundle savedInstanceState)
@@ -43,43 +63,29 @@ public class ImportExportActivity extends AppCompatActivity
                 .put(getResources().getString(R.string.zip), DataFormat.ZIP)
                 .build();
 
-        final Spinner fileFormatSpinner = (Spinner) findViewById(R.id.fileFormatSpinner);
-        List<String> names = new ArrayList<>(_fileFormatMap.keySet());
-        ArrayAdapter<String> dataAdapter = new ArrayAdapter<>(this,
-                android.R.layout.simple_spinner_item, names);
-        dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
-        fileFormatSpinner.setAdapter(dataAdapter);
-
-        updateHelpText();
-
-        fileFormatSpinner.setOnItemSelectedListener(new AdapterView.OnItemSelectedListener()
+        for(int id : new int[]{R.id.importFileFormatSpinner, R.id.exportFileFormatSpinner})
         {
-            @Override
-            public void onItemSelected(AdapterView<?> parent, View view, int position, long id)
-            {
-                updateHelpText();
-            }
+            final Spinner fileFormatSpinner = (Spinner) findViewById(id);
+            List<String> names = new ArrayList<>(_fileFormatMap.keySet());
+            ArrayAdapter<String> dataAdapter = new ArrayAdapter<>(this,
+                    android.R.layout.simple_spinner_item, names);
+            dataAdapter.setDropDownViewResource(android.R.layout.simple_spinner_dropdown_item);
+            fileFormatSpinner.setAdapter(dataAdapter);
+        }
 
-            @Override
-            public void onNothingSelected(AdapterView<?> parent)
-            {
-                // Nothing to do
-            }
-        });
+        // If the application does not have permissions to external
+        // storage, ask for it now
 
-        Button importButton = (Button)findViewById(R.id.importButton);
-        importButton.setOnClickListener(new View.OnClickListener()
+        if (ContextCompat.checkSelfPermission(ImportExportActivity.this,
+                Manifest.permission.READ_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED ||
+                ContextCompat.checkSelfPermission(ImportExportActivity.this,
+                        Manifest.permission.WRITE_EXTERNAL_STORAGE) != PackageManager.PERMISSION_GRANTED)
         {
-            @Override
-            public void onClick(View v)
-            {
-                Object selected = fileFormatSpinner.getSelectedItem();
-                DataFormat format = _fileFormatMap.get(selected);
-                importExporter = new ImportExportTask(ImportExportActivity.this,
-                        true, format);
-                importExporter.execute();
-            }
-        });
+            ActivityCompat.requestPermissions(ImportExportActivity.this,
+                    new String[]{Manifest.permission.READ_EXTERNAL_STORAGE,
+                            Manifest.permission.WRITE_EXTERNAL_STORAGE},
+                    PERMISSIONS_EXTERNAL_STORAGE);
+        }
 
         Button exportButton = (Button)findViewById(R.id.exportButton);
         exportButton.setOnClickListener(new View.OnClickListener()
@@ -87,24 +93,168 @@ public class ImportExportActivity extends AppCompatActivity
             @Override
             public void onClick(View v)
             {
-                Object selected = fileFormatSpinner.getSelectedItem();
-                DataFormat format = _fileFormatMap.get(selected);
-                importExporter = new ImportExportTask(ImportExportActivity.this,
-                        false, format);
-                importExporter.execute();
+                startExport(getSelectedFormat(R.id.exportFileFormatSpinner));
+            }
+        });
+
+
+        // Check that there is an activity that can bring up a file chooser
+        final Intent intentPickAction = new Intent(Intent.ACTION_PICK);
+        intentPickAction.setData(Uri.parse("file://"));
+
+        Button importFilesystem = (Button) findViewById(R.id.importOptionFilesystemButton);
+        importFilesystem.setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View v)
+            {
+                chooseFileWithIntent(intentPickAction);
+            }
+        });
+
+        if(isCallable(getApplicationContext(), intentPickAction) == false)
+        {
+            findViewById(R.id.dividerImportFilesystem).setVisibility(View.GONE);
+            findViewById(R.id.importOptionFilesystemTitle).setVisibility(View.GONE);
+            findViewById(R.id.importOptionFilesystemExplanation).setVisibility(View.GONE);
+            importFilesystem.setVisibility(View.GONE);
+        }
+
+
+        // Check that there is an application that can find content
+        final Intent intentGetContentAction = new Intent(Intent.ACTION_GET_CONTENT);
+        intentGetContentAction.addCategory(Intent.CATEGORY_OPENABLE);
+        intentGetContentAction.setType("*/*");
+
+        Button importApplication = (Button) findViewById(R.id.importOptionApplicationButton);
+        importApplication.setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View v)
+            {
+                chooseFileWithIntent(intentGetContentAction);
+            }
+        });
+
+        if(isCallable(getApplicationContext(), intentGetContentAction) == false)
+        {
+            findViewById(R.id.dividerImportApplication).setVisibility(View.GONE);
+            findViewById(R.id.importOptionApplicationTitle).setVisibility(View.GONE);
+            findViewById(R.id.importOptionApplicationExplanation).setVisibility(View.GONE);
+            importApplication.setVisibility(View.GONE);
+        }
+
+
+        // This option, to import from the fixed location, should always be present
+
+        Button importButton = (Button)findViewById(R.id.importOptionFixedButton);
+        importButton.setOnClickListener(new View.OnClickListener()
+        {
+            @Override
+            public void onClick(View v)
+            {
+                DataFormat format = getSelectedFormat(R.id.importFileFormatSpinner);
+                File importFile = new File(sdcardDir, exportFilename + "." + format.extension());
+
+                Log.d(TAG, "Starting import from fixed location: " + importFile.getAbsolutePath());
+                startImport(importFile, format);
             }
         });
     }
 
-    private void updateHelpText()
+    private DataFormat getSelectedFormat(int id)
     {
-        final Spinner fileFormatSpinner = (Spinner) findViewById(R.id.fileFormatSpinner);
-        String selection = (String)fileFormatSpinner.getSelectedItem();
-        selection = selection.toLowerCase();
-        String text = String.format(getString(R.string.importExportHelp), selection);
+        final Spinner fileFormatSpinner = (Spinner) findViewById(id);
+        String name = (String)fileFormatSpinner.getSelectedItem();
+        DataFormat format = _fileFormatMap.get(name);
+        return format;
+    }
 
-        TextView helpText = (TextView)findViewById(R.id.helpText);
-        helpText.setText(text);
+    private void startImport(File target, DataFormat format)
+    {
+        ImportExportTask.TaskCompleteListener listener = new ImportExportTask.TaskCompleteListener()
+        {
+            @Override
+            public void onTaskComplete(boolean success, File file)
+            {
+                onImportComplete(success, file);
+            }
+        };
+
+        if(format == null)
+        {
+            // Attempt to guess the data format based on the extension
+            Log.d(TAG, "Attempting to determine file type for: " + target.getName());
+
+            for(Map.Entry<String, DataFormat> item : _fileFormatMap.entrySet())
+            {
+                String key = item.getKey();
+                if(target.getName().toLowerCase().endsWith(key.toLowerCase()))
+                {
+                    format = item.getValue();
+                    break;
+                }
+            }
+        }
+
+        if(format != null)
+        {
+            Log.d(TAG, "Starting import of file: " + target.getName());
+            importExporter = new ImportExportTask(ImportExportActivity.this,
+                    true, format, target, listener);
+            importExporter.execute();
+        }
+        else
+        {
+            // If format is still null, then we do not know what to import
+            Log.w(TAG, "Could not import " + target.getAbsolutePath() + ", could not determine extension");
+            onImportComplete(false, target);
+        }
+    }
+
+    private void startExport(DataFormat format)
+    {
+        ImportExportTask.TaskCompleteListener listener = new ImportExportTask.TaskCompleteListener()
+        {
+            @Override
+            public void onTaskComplete(boolean success, File file)
+            {
+                onExportComplete(success, file);
+            }
+        };
+
+        File exportFile = new File(sdcardDir, exportFilename + "." + format.extension());
+
+        importExporter = new ImportExportTask(ImportExportActivity.this,
+                false, format, exportFile, listener);
+        importExporter.execute();
+    }
+
+    @Override
+    public void onRequestPermissionsResult(int requestCode, String permissions[], int[] grantResults)
+    {
+        if(requestCode == PERMISSIONS_EXTERNAL_STORAGE)
+        {
+            // If request is cancelled, the result arrays are empty.
+            boolean success = grantResults.length > 0;
+
+            for(int grant : grantResults)
+            {
+                if(grant != PackageManager.PERMISSION_GRANTED)
+                {
+                    success = false;
+                }
+            }
+
+            if(success == false)
+            {
+                // External storage permission rejected, inform user that
+                // import/export is prevented
+                Toast.makeText(getApplicationContext(), R.string.noExternalStoragePermissionError,
+                        Toast.LENGTH_LONG).show();
+            }
+
+        }
     }
 
     @Override
@@ -129,5 +279,160 @@ public class ImportExportActivity extends AppCompatActivity
         }
 
         return super.onOptionsItemSelected(item);
+    }
+
+    private void onImportComplete(boolean success, File path)
+    {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+        if(success)
+        {
+            builder.setTitle(R.string.importSuccessfulTitle);
+        }
+        else
+        {
+            builder.setTitle(R.string.importFailedTitle);
+        }
+
+        int messageId = success ? R.string.importedFrom : R.string.importFailed;
+
+        final String template = getResources().getString(messageId);
+        final String message = String.format(template, path.getAbsolutePath());
+        builder.setMessage(message);
+        builder.setNeutralButton(R.string.ok, new DialogInterface.OnClickListener()
+        {
+            @Override
+            public void onClick(DialogInterface dialog, int which)
+            {
+                dialog.dismiss();
+            }
+        });
+
+        builder.create().show();
+    }
+
+    private void onExportComplete(boolean success, final File path)
+    {
+        AlertDialog.Builder builder = new AlertDialog.Builder(this);
+
+        if(success)
+        {
+            builder.setTitle(R.string.exportSuccessfulTitle);
+        }
+        else
+        {
+            builder.setTitle(R.string.exportFailedTitle);
+        }
+
+        int messageId = success ? R.string.exportedTo : R.string.exportFailed;
+
+        final String template = getResources().getString(messageId);
+        final String message = String.format(template, path.getAbsolutePath());
+        builder.setMessage(message);
+        builder.setNeutralButton(R.string.ok, new DialogInterface.OnClickListener()
+        {
+            @Override
+            public void onClick(DialogInterface dialog, int which)
+            {
+                dialog.dismiss();
+            }
+        });
+
+        if(success)
+        {
+            final CharSequence sendLabel = ImportExportActivity.this.getResources().getText(R.string.sendLabel);
+
+            builder.setPositiveButton(sendLabel, new DialogInterface.OnClickListener()
+            {
+                @Override
+                public void onClick(DialogInterface dialog, int which)
+                {
+                    Uri outputUri = Uri.fromFile(path);
+                    Intent sendIntent = new Intent(Intent.ACTION_SEND);
+                    sendIntent.putExtra(Intent.EXTRA_STREAM, outputUri);
+                    sendIntent.setType("text/plain");
+
+                    ImportExportActivity.this.startActivity(Intent.createChooser(sendIntent,
+                            sendLabel));
+
+                    dialog.dismiss();
+                }
+            });
+        }
+
+        builder.create().show();
+    }
+
+    /**
+     * Determines if there is at least one activity that can perform the given intent
+     */
+    private boolean isCallable(Context context, final Intent intent)
+    {
+        PackageManager manager = context.getPackageManager();
+        if(manager == null)
+        {
+            return false;
+        }
+
+        List<ResolveInfo> list = manager.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY);
+
+        for(ResolveInfo info : list)
+        {
+            if(info.activityInfo.exported)
+            {
+                // There is one activity which is available to be called
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private void chooseFileWithIntent(Intent intent)
+    {
+        try
+        {
+            startActivityForResult(intent, CHOOSE_EXPORT_FILE);
+        }
+        catch (ActivityNotFoundException e)
+        {
+            Log.e(TAG, "No activity found to handle intent", e);
+        }
+    }
+
+    @Override
+    protected void onActivityResult(int requestCode, int resultCode, Intent data)
+    {
+        super.onActivityResult(requestCode, resultCode, data);
+
+        if (resultCode == RESULT_OK && requestCode == CHOOSE_EXPORT_FILE)
+        {
+            String path = null;
+
+            Uri uri = data.getData();
+            if(uri != null && uri.toString().startsWith("/"))
+            {
+                uri = Uri.parse("file://" + uri.toString());
+            }
+
+            if(uri != null)
+            {
+                path = uri.getPath();
+            }
+
+            if(path != null)
+            {
+                Log.e(TAG, "Starting file import with: " + uri.toString());
+                startImport(new File(path), null);
+            }
+            else
+            {
+                Log.e(TAG, "Fail to make sense of URI returned from activity: " + (uri != null ? uri.toString() : "null"));
+            }
+        }
+        else
+        {
+            Log.w(TAG, "Failed onActivityResult(), result=" + resultCode);
+        }
     }
 }

--- a/app/src/main/java/protect/budgetwatch/ImportExportTask.java
+++ b/app/src/main/java/protect/budgetwatch/ImportExportTask.java
@@ -16,49 +16,31 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.nio.charset.Charset;
 
-class ImportExportTask extends AsyncTask<Void, Void, Void>
+class ImportExportTask extends AsyncTask<Void, Void, Boolean>
 {
     private static final String TAG = "BudgetWatch";
-
-    private static final String TARGET_FILE_NAME = "BudgetWatch";
 
     private Activity activity;
     private boolean doImport;
     private DataFormat format;
+    private File target;
+    private TaskCompleteListener listener;
 
     private ProgressDialog progress;
 
-    public ImportExportTask(Activity activity, boolean doImport, DataFormat format)
+    public ImportExportTask(Activity activity, boolean doImport, DataFormat format,
+                            File target, TaskCompleteListener listener)
     {
         super();
         this.activity = activity;
         this.doImport = doImport;
         this.format = format;
+        this.target = target;
+        this.listener = listener;
     }
 
-    private void toastWithArg(int stringId, String argument)
+    private boolean performImport(File importFile, DBHelper db)
     {
-        final String template = activity.getResources().getString(stringId);
-        final String message = String.format(template, argument);
-
-        activity.runOnUiThread(new Runnable()
-        {
-            @Override
-            public void run()
-            {
-                Toast.makeText(activity, message, Toast.LENGTH_LONG).show();
-            }
-        });
-    }
-
-    private void performImport(File importFile, DBHelper db)
-    {
-        if(importFile.exists() == false)
-        {
-            toastWithArg(R.string.fileMissing, importFile.getAbsolutePath());
-            return;
-        }
-
         boolean result = false;
 
         try
@@ -72,11 +54,11 @@ class ImportExportTask extends AsyncTask<Void, Void, Void>
             Log.e(TAG, "Unable to import file", e);
         }
 
-        int messageId = result ? R.string.importedFrom : R.string.importFailed;
-        toastWithArg(messageId, importFile.getAbsolutePath());
+        Log.i(TAG, "Import of '" + importFile.getAbsolutePath() + "' result: " + result);
+        return result;
     }
 
-    private void performExport(File exportFile, DBHelper db)
+    private boolean performExport(File exportFile, DBHelper db)
     {
         boolean result = false;
 
@@ -91,8 +73,9 @@ class ImportExportTask extends AsyncTask<Void, Void, Void>
             Log.e(TAG, "Unable to export file", e);
         }
 
-        int messageId = result ? R.string.exportedTo : R.string.exportFailed;
-        toastWithArg(messageId, exportFile.getAbsolutePath());
+        Log.i(TAG, "Export of '" + exportFile.getAbsolutePath() + "' result: " + result);
+
+        return result;
     }
 
     protected void onPreExecute()
@@ -112,31 +95,29 @@ class ImportExportTask extends AsyncTask<Void, Void, Void>
         progress.show();
     }
 
-    protected Void doInBackground(Void... nothing)
+    protected Boolean doInBackground(Void... nothing)
     {
-        final File sdcardDir = Environment.getExternalStorageDirectory();
-
-        String filename = TARGET_FILE_NAME + "." + format.name().toLowerCase();
-
-        final File importExportFile = new File(sdcardDir, filename);
+        boolean result;
         final DBHelper db = new DBHelper(activity);
 
         if(doImport)
         {
-            performImport(importExportFile, db);
+            result = performImport(target, db);
         }
         else
         {
-            performExport(importExportFile, db);
+            result = performExport(target, db);
         }
 
         db.close();
 
-        return null;
+        return result;
     }
 
-    protected void onPostExecute(Void result)
+    protected void onPostExecute(Boolean result)
     {
+        listener.onTaskComplete(result, target);
+
         progress.dismiss();
         Log.i(TAG, (doImport ? "Import" : "Export") + " Complete");
     }
@@ -145,5 +126,10 @@ class ImportExportTask extends AsyncTask<Void, Void, Void>
     {
         progress.dismiss();
         Log.i(TAG, (doImport ? "Import" : "Export") + " Cancelled");
+    }
+
+    interface TaskCompleteListener
+    {
+        void onTaskComplete(boolean success, File file);
     }
 }

--- a/app/src/main/res/layout/import_export_activity.xml
+++ b/app/src/main/res/layout/import_export_activity.xml
@@ -1,11 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
                                                  xmlns:app="http://schemas.android.com/apk/res-auto"
-                                                 xmlns:tools="http://schemas.android.com/tools"
                                                  android:layout_width="match_parent"
                                                  android:layout_height="match_parent"
-                                                 android:fitsSystemWindows="true"
-                                                 tools:context="protect.budgetwatch.AccountsActivity">
+                                                 android:fitsSystemWindows="true">
 
     <android.support.design.widget.AppBarLayout
         android:layout_width="match_parent"

--- a/app/src/main/res/layout/import_export_activity.xml
+++ b/app/src/main/res/layout/import_export_activity.xml
@@ -19,58 +19,201 @@
 
     </android.support.design.widget.AppBarLayout>
 
-    <LinearLayout android:orientation="vertical"
-                  android:layout_width="fill_parent"
-                  android:layout_height="fill_parent"
-                  app:layout_behavior="@string/appbar_scrolling_view_behavior">
-        <TextView
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="20dp"
-            android:textSize="20sp"
-            android:layout_gravity="center"
-            android:id="@+id/helpText"/>
+    <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:fillViewport="true"
+                app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <LinearLayout
-            android:orientation="horizontal"
-            android:layout_width="fill_parent"
-            android:layout_height="wrap_content"
-            android:padding="20dp">
-            <TextView
-                android:textSize="20sp"
-                android:layout_gravity="center_vertical"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:labelFor="@+id/budgetSpinner"
-                android:text="@string/fileFormat" />
-            <Spinner
-                android:id="@+id/fileFormatSpinner"
-                android:layout_width="fill_parent"
-                android:layout_height="wrap_content"
-                android:textSize="20sp"
-                android:paddingStart="20dp"
-                android:paddingEnd="20dp"
-                android:drawSelectorOnTop="true" />
-        </LinearLayout>
-
-        <LinearLayout android:orientation="horizontal"
+        <LinearLayout android:orientation="vertical"
                       android:layout_width="fill_parent"
-                      android:layout_height="fill_parent">
-            <Button
+                      android:layout_height="wrap_content"
+                      android:paddingTop="8dp"
+                      android:paddingLeft="16dp"
+                      android:paddingRight="16dp"
+                      android:paddingBottom="8dp">
+            <TextView
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/importName"
-                android:layout_weight="1.0"
-                android:id="@+id/importButton"/>
-            <Button
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:text="@string/exportName"
-                android:layout_weight="1.0"
-                android:id="@+id/exportButton"/>
-        </LinearLayout>
+                android:textSize="@dimen/text_size_medium"
+                android:layout_gravity="center"
+                android:text="@string/importExportHelp"/>
 
-    </LinearLayout>
+            <View
+                android:id="@+id/dividerExport"
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:layout_margin="16dp"
+                android:background="?android:attr/listDivider"/>
+
+            <TextView
+                android:id="@+id/exportOptionTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="@dimen/text_size_large"
+                android:text="@string/exportName"/>
+
+            <TextView
+                android:id="@+id/exportOptionExplanation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textSize="@dimen/text_size_medium"
+                android:text="@string/exportOptionExplanation"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingTop="10dp"
+                android:paddingBottom="10dp">
+                <TextView
+                    android:id="@+id/exportFileFormatSpinnerLabel"
+                    android:textSize="@dimen/text_size_medium"
+                    android:layout_gravity="start"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:labelFor="@+id/exportFileFormatSpinner"
+                    android:text="@string/fileFormat" />
+
+                <Spinner
+                    android:id="@+id/exportFileFormatSpinner"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:textSize="@dimen/text_size_medium"
+                    android:paddingStart="20dp"
+                    android:paddingEnd="20dp"
+                    android:drawSelectorOnTop="true" />
+            </LinearLayout>
+
+            <Button
+                android:id="@+id/exportButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="8dp"
+                android:text="@string/exportName" />
+
+            <View
+                android:id="@+id/dividerImportFilesystem"
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:layout_margin="16dp"
+                android:background="?android:attr/listDivider"/>
+
+            <TextView
+                android:id="@+id/importOptionFilesystemTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="@dimen/text_size_large"
+                android:text="@string/importOptionFilesystemTitle"/>
+
+            <TextView
+                android:id="@+id/importOptionFilesystemExplanation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textSize="@dimen/text_size_medium"
+                android:text="@string/importOptionFilesystemExplanation"/>
+
+            <Button
+                android:id="@+id/importOptionFilesystemButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="8dp"
+                android:text="@string/importOptionFilesystemButton" />
+
+
+            <View
+                android:id="@+id/dividerImportApplication"
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:layout_margin="16dp"
+                android:background="?android:attr/listDivider"/>
+
+            <TextView
+                android:id="@+id/importOptionApplicationTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="@dimen/text_size_large"
+                android:text="@string/importOptionApplicationTitle"/>
+
+            <TextView
+                android:id="@+id/importOptionApplicationExplanation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textSize="@dimen/text_size_medium"
+                android:text="@string/importOptionApplicationExplanation"/>
+
+            <Button
+                android:id="@+id/importOptionApplicationButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="8dp"
+                android:text="@string/importOptionApplicationButton" />
+
+
+            <View
+                android:id="@+id/dividerImportFixed"
+                android:layout_width="fill_parent"
+                android:layout_height="1dp"
+                android:layout_margin="16dp"
+                android:background="?android:attr/listDivider"/>
+
+            <TextView
+                android:id="@+id/importOptionFixedTitle"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:textSize="@dimen/text_size_large"
+                android:text="@string/importOptionFixedTitle"/>
+
+            <TextView
+                android:id="@+id/importOptionFixedExplanation"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_marginTop="4dp"
+                android:textSize="@dimen/text_size_medium"
+                android:text="@string/importOptionFixedExplanation"/>
+
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal"
+                android:paddingTop="10dp"
+                android:paddingBottom="10dp">
+                <TextView
+                    android:id="@+id/importOptionFixedFileFormatSpinnerLabel"
+                    android:textSize="@dimen/text_size_medium"
+                    android:layout_gravity="start"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:labelFor="@+id/importFileFormatSpinner"
+                    android:text="@string/fileFormat" />
+
+                <Spinner
+                    android:id="@+id/importFileFormatSpinner"
+                    android:layout_width="fill_parent"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="end"
+                    android:textSize="@dimen/text_size_medium"
+                    android:paddingStart="20dp"
+                    android:paddingEnd="20dp"
+                    android:drawSelectorOnTop="true" />
+            </LinearLayout>
+            
+            <Button
+                android:id="@+id/importOptionFixedButton"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:layout_marginTop="8dp"
+                android:text="@string/importOptionFixedButton" />
+        </LinearLayout>
+    </ScrollView>
 
 
 </android.support.design.widget.CoordinatorLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -67,7 +67,6 @@
     <string name="importExport">Import/Export</string>
     <string name="importName">Import</string>
     <string name="exportName">Export</string>
-    <string name="importExportHelp">Daten werden importiert nach/exportiert von BudgetWatch.<xliff:g id="extension">%s</xliff:g> im externen Speicher</string>
     <string name="importedFrom">Importiert von: %1$s</string>
     <string name="exportedTo">Exportiert nach: %1$s</string>
     <string name="fileMissing">Datei fehlt: %1$s</string>
@@ -112,5 +111,23 @@
     <string name="deleteTransactionTitle">Transaktion entfernen</string>
     <string name="deleteTransactionConfirmation">Bitte bestätigen Sie die Löschung dieser Transaktion.</string>
     <string name="fileFormat">Datei format</string>
+
+    <!-- needs translated --><string name="importExportHelp">Backed up data can allow you to move your budgets and transactions to another device.</string>
+    <!-- needs translated --><string name="importSuccessfulTitle">Import successful</string>
+    <!-- needs translated --><string name="importFailedTitle">Import failed</string>
+    <!-- needs translated --><string name="exportSuccessfulTitle">Export successful</string>
+    <!-- needs translated --><string name="exportFailedTitle">Export failed</string>
+    <!-- needs translated --><string name="noExternalStoragePermissionError">Unable to import or export cards without the external storage permission</string>
+    <!-- needs translated --><string name="exportOptionExplanation">Data is written to the top directory in external storage.</string>
+    <!-- needs translated --><string name="importOptionFilesystemTitle">Import from filesystem</string>
+    <!-- needs translated --><string name="importOptionFilesystemExplanation">Choose a specific file from the filesystem.</string>
+    <!-- needs translated --><string name="importOptionFilesystemButton">From filesystem</string>
+    <!-- needs translated --><string name="importOptionApplicationTitle">Import from filesystem</string>
+    <!-- needs translated --><string name="importOptionApplicationExplanation">Use an external application like Dropbox, Google Drive, or your favorite file manager to open a file.</string>
+    <!-- needs translated --><string name="importOptionApplicationButton">Use external application</string>
+    <!-- needs translated --><string name="importOptionFixedTitle">Import from export location</string>
+    <!-- needs translated --><string name="importOptionFixedExplanation">Import from the same location on the filesystem that is written to on export.</string>
+    <!-- needs translated --><string name="importOptionFixedButton">Use export location</string>
+    <!-- needs translated --><string name="sendLabel">Send&#8230;</string>
 </resources>
 

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -4,4 +4,7 @@
 
     <dimen name="receipt_icon_size">18dp</dimen>
     <dimen name="receipt_icon_padding">2dp</dimen>
+
+    <dimen name="text_size_medium">18sp</dimen>
+    <dimen name="text_size_large">22sp</dimen>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -76,7 +76,6 @@
     <string name="importExport">Import/Export</string>
     <string name="importName">Import</string>
     <string name="exportName">Export</string>
-    <string name="importExportHelp">Data is imported to/exported from BudgetWatch.<xliff:g id="extension">%s</xliff:g> on external storage</string>
     <string name="importedFrom">Imported from: %1$s</string>
     <string name="fileFormat">File format</string>
     <string name="exportedTo">Exported to: %1$s</string>
@@ -117,4 +116,22 @@
 
     <string name="csv" translatable="false">CSV</string>
     <string name="zip" translatable="false">Zip</string>
+
+    <string name="importExportHelp">Backed up data can allow you to move your budgets and transactions to another device.</string>
+    <string name="importSuccessfulTitle">Import successful</string>
+    <string name="importFailedTitle">Import failed</string>
+    <string name="exportSuccessfulTitle">Export successful</string>
+    <string name="exportFailedTitle">Export failed</string>
+    <string name="noExternalStoragePermissionError">Unable to import or export cards without the external storage permission</string>
+    <string name="exportOptionExplanation">Data is written to the top directory in external storage.</string>
+    <string name="importOptionFilesystemTitle">Import from filesystem</string>
+    <string name="importOptionFilesystemExplanation">Choose a specific file from the filesystem.</string>
+    <string name="importOptionFilesystemButton">From filesystem</string>
+    <string name="importOptionApplicationTitle">Import from filesystem</string>
+    <string name="importOptionApplicationExplanation">Use an external application like Dropbox, Google Drive, or your favorite file manager to open a file.</string>
+    <string name="importOptionApplicationButton">Use external application</string>
+    <string name="importOptionFixedTitle">Import from export location</string>
+    <string name="importOptionFixedExplanation">Import from the same location on the filesystem that is written to on export.</string>
+    <string name="importOptionFixedButton">Use export location</string>
+    <string name="sendLabel">Send&#8230;</string>
 </resources>

--- a/app/src/test/java/protect/budgetwatch/ImportExportActivityTest.java
+++ b/app/src/test/java/protect/budgetwatch/ImportExportActivityTest.java
@@ -1,0 +1,172 @@
+package protect.budgetwatch;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.ResolveInfo;
+import android.net.Uri;
+import android.view.View;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricGradleTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+import org.robolectric.res.builder.RobolectricPackageManager;
+
+import static org.robolectric.Shadows.shadowOf;
+
+import static org.junit.Assert.assertEquals;
+
+@RunWith(RobolectricGradleTestRunner.class)
+@Config(constants = BuildConfig.class, sdk = 17)
+public class ImportExportActivityTest
+{
+    private void registerIntentHandler(String handler)
+    {
+        // Add something that will 'handle' the given intent type
+
+        RobolectricPackageManager packageManager = (RobolectricPackageManager) shadowOf(
+                RuntimeEnvironment.application).getPackageManager();
+
+        ResolveInfo info = new ResolveInfo();
+        info.isDefault = true;
+
+        ApplicationInfo applicationInfo = new ApplicationInfo();
+        applicationInfo.packageName = "does.not.matter";
+        info.activityInfo = new ActivityInfo();
+        info.activityInfo.applicationInfo = applicationInfo;
+        info.activityInfo.name = "DoesNotMatter";
+        info.activityInfo.exported = true;
+
+        Intent intent = new Intent(handler);
+        if(handler.equals(Intent.ACTION_PICK))
+        {
+            intent.setData(Uri.parse("file://"));
+        }
+
+        if(handler.equals(Intent.ACTION_GET_CONTENT))
+        {
+            intent.addCategory(Intent.CATEGORY_OPENABLE);
+            intent.setType("*/*");
+        }
+
+        packageManager.addResolveInfoForIntent(intent, info);
+    }
+
+    private void checkVisibility(Activity activity, Integer state, Integer divider, Integer title,
+                                 Integer message, Integer label, Integer spinner, Integer button)
+    {
+        View dividerView = activity.findViewById(divider);
+        assertEquals(state.intValue(), dividerView.getVisibility());
+
+        View titleView = activity.findViewById(title);
+        assertEquals(state.intValue(), titleView.getVisibility());
+
+        View messageView = activity.findViewById(message);
+        assertEquals(state.intValue(), messageView.getVisibility());
+
+        if(label != null)
+        {
+            View labelView = activity.findViewById(label);
+            assertEquals(state.intValue(), labelView.getVisibility());
+        }
+
+        if(spinner != null)
+        {
+            View spinnerView = activity.findViewById(spinner);
+            assertEquals(state.intValue(), spinnerView.getVisibility());
+        }
+
+        View buttonView = activity.findViewById(button);
+        assertEquals(state.intValue(), buttonView.getVisibility());
+    }
+
+    @Test
+    public void testImportFilesystemOption()
+    {
+        for(boolean isInstalled : new Boolean[]{false, true})
+        {
+            int visibility = isInstalled ? View.VISIBLE : View.GONE;
+
+            if(isInstalled)
+            {
+                registerIntentHandler(Intent.ACTION_PICK);
+            }
+
+            Activity activity = Robolectric.setupActivity(ImportExportActivity.class);
+
+            checkVisibility(activity, visibility, R.id.dividerImportFilesystem,
+                    R.id.importOptionFilesystemTitle, R.id.importOptionFilesystemExplanation,
+                    null, null, R.id.importOptionFilesystemButton);
+
+            // Should always be gone, as its provider is never installed
+            checkVisibility(activity, View.GONE, R.id.dividerImportApplication,
+                    R.id.importOptionApplicationTitle, R.id.importOptionApplicationExplanation,
+                    null, null, R.id.importOptionApplicationButton);
+
+            // Import from file system should always be present
+
+            checkVisibility(activity, View.VISIBLE, R.id.dividerImportFixed,
+                    R.id.importOptionFixedTitle, R.id.importOptionFixedExplanation,
+                    R.id.importOptionFixedFileFormatSpinnerLabel, R.id.importFileFormatSpinner,
+                    R.id.importOptionFixedButton);
+        }
+    }
+
+    @Test
+    public void testImportApplicationOption()
+    {
+        for(boolean isInstalled : new Boolean[]{false, true})
+        {
+            int visibility = isInstalled ? View.VISIBLE : View.GONE;
+
+            if(isInstalled)
+            {
+                registerIntentHandler(Intent.ACTION_GET_CONTENT);
+            }
+
+            Activity activity = Robolectric.setupActivity(ImportExportActivity.class);
+
+            checkVisibility(activity, visibility, R.id.dividerImportApplication,
+                    R.id.importOptionApplicationTitle, R.id.importOptionApplicationExplanation,
+                    null, null, R.id.importOptionApplicationButton);
+
+            // Should always be gone, as its provider is never installed
+            checkVisibility(activity, View.GONE, R.id.dividerImportFilesystem,
+                    R.id.importOptionFilesystemTitle, R.id.importOptionFilesystemExplanation,
+                    null, null, R.id.importOptionFilesystemButton);
+
+            // Import from file system should always be present
+
+            checkVisibility(activity, View.VISIBLE, R.id.dividerImportFixed,
+                    R.id.importOptionFixedTitle, R.id.importOptionFixedExplanation,
+                    R.id.importOptionFixedFileFormatSpinnerLabel, R.id.importFileFormatSpinner,
+                    R.id.importOptionFixedButton);
+        }
+    }
+
+    @Test
+    public void testAllOptionsAvailable()
+    {
+        registerIntentHandler(Intent.ACTION_PICK);
+        registerIntentHandler(Intent.ACTION_GET_CONTENT);
+
+        Activity activity = Robolectric.setupActivity(ImportExportActivity.class);
+
+        checkVisibility(activity, View.VISIBLE, R.id.dividerImportApplication,
+                R.id.importOptionApplicationTitle, R.id.importOptionApplicationExplanation,
+                null, null, R.id.importOptionApplicationButton);
+
+        checkVisibility(activity, View.VISIBLE, R.id.dividerImportFilesystem,
+                R.id.importOptionFilesystemTitle, R.id.importOptionFilesystemExplanation,
+                null, null, R.id.importOptionFilesystemButton);
+
+        checkVisibility(activity, View.VISIBLE, R.id.dividerImportFixed,
+                R.id.importOptionFixedTitle, R.id.importOptionFixedExplanation,
+                R.id.importOptionFixedFileFormatSpinnerLabel, R.id.importFileFormatSpinner,
+                R.id.importOptionFixedButton);
+    }
+}


### PR DESCRIPTION
This adds improvements to the import/export activity. Before the import/export location was hard-coded. Now, importing is more flexible, as the file to import can be pointed to using a separate application (where available):

![screenshot_2017-01-19-21-57-18](https://cloud.githubusercontent.com/assets/5264535/22134420/c9a4aa68-de94-11e6-94a2-787f40b9fbb4.png)

![screenshot_2017-01-19-21-57-33](https://cloud.githubusercontent.com/assets/5264535/22134381/8e0e22ae-de94-11e6-987d-478668b7f866.png)

![screenshot_2017-01-19-21-58-15](https://cloud.githubusercontent.com/assets/5264535/22134436/e6fd815c-de94-11e6-9d5c-70dd6b33af0d.png)

In addition, once an export has been done the file can be easily shared by clicking the "Send..." button in the export complete dialog:

![screenshot_2017-01-19-21-57-55](https://cloud.githubusercontent.com/assets/5264535/22134442/f7cd9274-de94-11e6-9263-12c283d57dbc.png)

