### PR TITLE
Skip downloading extras during travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,6 @@ android:
     # The SDK version used to compile your project
     - android-23
 
-    # Additional components
-    - extra
-
 script: ./gradlew build lint findbugs test
 
 after_failure:


### PR DESCRIPTION
The application does not need the google play store, or other extras.
Skip downloading the Android extras, as they should be unnecessary.