### PR TITLE
Add note summary to transaction entry

### DIFF
--- a/app/src/main/java/protect/budgetwatch/TransactionCursorAdapter.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionCursorAdapter.java
@@ -28,6 +28,8 @@ class TransactionCursorAdapter extends CursorAdapter
         TextView dateField;
         TextView budgetField;
         ImageView receiptIcon;
+        TextView note;
+        View noteLayout;
     }
 
     // The newView method is used to inflate a new view and return it,
@@ -43,6 +45,8 @@ class TransactionCursorAdapter extends CursorAdapter
         holder.dateField = (TextView) view.findViewById(R.id.date);
         holder.budgetField = (TextView) view.findViewById(R.id.budget);
         holder.receiptIcon = (ImageView) view.findViewById(R.id.receiptIcon);
+        holder.note = (TextView) view.findViewById(R.id.note);
+        holder.noteLayout = view.findViewById(R.id.noteLayout);
         view.setTag(holder);
 
         return view;
@@ -72,6 +76,17 @@ class TransactionCursorAdapter extends CursorAdapter
         else
         {
             holder.receiptIcon.setVisibility(View.VISIBLE);
+        }
+
+        if(transaction.note.isEmpty())
+        {
+            holder.noteLayout.setVisibility(View.GONE);
+            holder.note.setText("");
+        }
+        else
+        {
+            holder.noteLayout.setVisibility(View.VISIBLE);
+            holder.note.setText(transaction.note);
         }
     }
 }

--- a/app/src/main/res/layout/transaction_layout.xml
+++ b/app/src/main/res/layout/transaction_layout.xml
@@ -51,4 +51,16 @@
                       android:layout_height="fill_parent"/>
         </LinearLayout>
     </LinearLayout>
+    <LinearLayout android:orientation="horizontal"
+                  android:paddingBottom="5.0dp"
+                  android:paddingTop="2.0dp"
+                  android:layout_width="fill_parent"
+                  android:layout_height="wrap_content"
+                  android:id="@+id/noteLayout">
+        <TextView android:id="@+id/note"
+                  android:layout_width="0dp"
+                  android:layout_height="wrap_content"
+                  android:layout_weight="1.0"
+                  android:singleLine="true"/>
+    </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/transaction_layout.xml
+++ b/app/src/main/res/layout/transaction_layout.xml
@@ -27,7 +27,7 @@
         </LinearLayout>
     </LinearLayout>
     <LinearLayout android:orientation="horizontal"
-                  android:padding="5.0dp"
+                  android:paddingTop="5.0dp"
                   android:layout_width="fill_parent"
                   android:layout_height="wrap_content">
         <ImageView android:id="@+id/receiptIcon"

--- a/app/src/test/java/protect/budgetwatch/TransactionCursorAdapterTest.java
+++ b/app/src/test/java/protect/budgetwatch/TransactionCursorAdapterTest.java
@@ -54,36 +54,44 @@ public class TransactionCursorAdapterTest
 
         for(boolean hasReceipt : new boolean [] {false, true})
         {
-            db.insertTransaction(DBHelper.TransactionDbIds.EXPENSE, DESCRIPTION, ACCOUNT, BUDGET,
-                    VALUE, NOTE, DATE, hasReceipt ? RECEIPT : "");
-            Cursor cursor = db.getExpenses();
-            cursor.moveToFirst();
-            int transactionId = cursor.getInt(
-                    cursor.getColumnIndexOrThrow(DBHelper.TransactionDbIds.NAME));
+            for(boolean hasNote : new boolean [] {false, true})
+            {
+                db.insertTransaction(DBHelper.TransactionDbIds.EXPENSE, DESCRIPTION, ACCOUNT, BUDGET,
+                        VALUE, hasNote ? NOTE : "", DATE, hasReceipt ? RECEIPT : "");
+                Cursor cursor = db.getExpenses();
+                cursor.moveToFirst();
+                int transactionId = cursor.getInt(
+                        cursor.getColumnIndexOrThrow(DBHelper.TransactionDbIds.NAME));
 
-            TransactionCursorAdapter adapter = new TransactionCursorAdapter(activity, cursor);
-            View view = adapter.newView(activity, cursor, null);
-            adapter.bindView(view, activity, cursor);
-            cursor.close();
+                TransactionCursorAdapter adapter = new TransactionCursorAdapter(activity, cursor);
+                View view = adapter.newView(activity, cursor, null);
+                adapter.bindView(view, activity, cursor);
+                cursor.close();
 
-            db.deleteTransaction(transactionId);
+                db.deleteTransaction(transactionId);
 
-            TextView nameField = (TextView) view.findViewById(R.id.name);
-            TextView valueField = (TextView) view.findViewById(R.id.value);
-            TextView dateField = (TextView) view.findViewById(R.id.date);
-            TextView budgetField = (TextView) view.findViewById(R.id.budget);
-            ImageView receiptIcon = (ImageView) view.findViewById(R.id.receiptIcon);
+                TextView nameField = (TextView) view.findViewById(R.id.name);
+                TextView valueField = (TextView) view.findViewById(R.id.value);
+                TextView dateField = (TextView) view.findViewById(R.id.date);
+                TextView budgetField = (TextView) view.findViewById(R.id.budget);
+                ImageView receiptIcon = (ImageView) view.findViewById(R.id.receiptIcon);
+                View noteLayout = view.findViewById(R.id.noteLayout);
+                TextView noteField = (TextView) view.findViewById(R.id.note);
 
-            assertEquals(hasReceipt ? View.VISIBLE : View.GONE, receiptIcon.getVisibility());
-            assertEquals(DESCRIPTION, nameField.getText().toString());
-            assertEquals(BUDGET, budgetField.getText().toString());
+                assertEquals(hasReceipt ? View.VISIBLE : View.GONE, receiptIcon.getVisibility());
+                assertEquals(DESCRIPTION, nameField.getText().toString());
+                assertEquals(BUDGET, budgetField.getText().toString());
 
-            String expectedValue = String.format("%.2f", VALUE);
-            assertEquals(expectedValue, valueField.getText().toString());
+                String expectedValue = String.format("%.2f", VALUE);
+                assertEquals(expectedValue, valueField.getText().toString());
 
-            // As the date field may be converted using the current locale,
-            // simply check that there is something there.
-            assertTrue(dateField.getText().length() > 0);
+                // As the date field may be converted using the current locale,
+                // simply check that there is something there.
+                assertTrue(dateField.getText().length() > 0);
+
+                assertEquals(hasNote ? View.VISIBLE : View.GONE, noteLayout.getVisibility());
+                assertEquals(hasNote ? NOTE : "", noteField.getText());
+            }
         }
     }
 }


### PR DESCRIPTION
This adds the first line of the note text to the transactions listed on the transaction screen. In addition, the padding on the second line was decreased so the first, second, and third line start and stop at the same place.

![example](https://cloud.githubusercontent.com/assets/5264535/22319099/c66076da-e34d-11e6-8962-13387db3259b.png)
