### PR TITLE
Build in parallel during Travis-CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ android:
     # The SDK version used to compile your project
     - android-23
 
-script: ./gradlew build lint findbugs test
+script: ./gradlew --parallel build lint findbugs test
 
 after_failure:
 - cat app/build/outputs/lint-results*


### PR DESCRIPTION
Use the --parallel flag when building and testing with gradle,
to hopefully reduce build and test times.