### PR TITLE
Remove requirement to have complete translations

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,7 @@ android {
       disable "IconDipSize"
       disable "AlwaysShowAction"
       disable "InflateParams"
+      disable "MissingTranslation"
    }
 
    // This is for Robolectric support for SDK 23

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -97,7 +97,7 @@
     <string name="debug_version_fmt">Version: <xliff:g id="version">%s</xliff:g></string>
     <string name="app_revision_fmt">Release-Informationen: <xliff:g id="app_revision_url">%s</xliff:g></string>
     <string name="app_libraries"><xliff:g id="app_name">%s</xliff:g> benutzt die folgenden Dritt-Anbieter-Bibliotheken: <xliff:g id="app_libraries_list">%s</xliff:g></string>
-    <!-- needs translated --> <string name="app_resources"><xliff:g id="app_name">%s</xliff:g> uses the following third-party resources: <xliff:g id="app_resources_list">%s</xliff:g></string>
+
     <string name="share">Teilen</string>
     <string name="totalBudgetTitle">Gesamt</string>
     <string name="settings">Einstellungen</string>


### PR DESCRIPTION
Translations and completness is now tracked on Transifex:

https://www.transifex.com/na-243/budget-watch