### PR TITLE
Remove context menu for transactions

### DIFF
--- a/app/src/main/java/protect/budgetwatch/TransactionFragment.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionFragment.java
@@ -123,49 +123,6 @@ public class TransactionFragment extends Fragment
     }
 
     @Override
-    public void onCreateContextMenu(ContextMenu menu, View v, ContextMenuInfo menuInfo)
-    {
-        super.onCreateContextMenu(menu, v, menuInfo);
-        if (v.getId()==R.id.list)
-        {
-            MenuInflater inflater = getActivity().getMenuInflater();
-            inflater.inflate(R.menu.view_menu, menu);
-        }
-    }
-
-    @Override
-    public boolean onContextItemSelected(MenuItem item)
-    {
-        AdapterContextMenuInfo info = (AdapterContextMenuInfo) item.getMenuInfo();
-        ListView listView = (ListView) getActivity().findViewById(R.id.list);
-
-        if(info != null)
-        {
-            Cursor selected = (Cursor) listView.getItemAtPosition(info.position);
-
-            if (selected != null)
-            {
-                Transaction transaction = Transaction.toTransaction(selected);
-
-                if (item.getItemId() == R.id.action_edit)
-                {
-                    Intent i = new Intent(getActivity(), TransactionViewActivity.class);
-                    final Bundle b = new Bundle();
-                    b.putInt("id", transaction.id);
-                    b.putInt("type", _transactionType);
-                    b.putBoolean("update", true);
-                    i.putExtras(b);
-                    startActivity(i);
-
-                    return true;
-                }
-            }
-        }
-
-        return super.onContextItemSelected(item);
-    }
-
-    @Override
     public void onDestroyView()
     {
         _db.close();


### PR DESCRIPTION
This functionality is duplicated, as one can click
on a transaction and then click on the edit menu item.
Because of this, the context menu is unnecessary.

In addition, there is a bug where searching a list
of transactions, then editing one via the context menu,
returning, then attempting to edit again resulted in
the transaction list being empty. Removing the context
menu, which is unnecessary, removes the need to resolve
this bug.