### PR TITLE
Allow keyboard to appear when adding/editing budget/transaction

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -33,8 +33,7 @@
         <activity
             android:name=".BudgetViewActivity"
             android:configChanges="orientation|screenSize"
-            android:theme="@style/AppTheme.NoActionBar"
-            android:windowSoftInputMode="stateHidden"/>
+            android:theme="@style/AppTheme.NoActionBar"/>
         <activity
             android:name=".TransactionActivity"
             android:label="@string/transactionsTitle"
@@ -52,8 +51,7 @@
             android:name=".TransactionViewActivity"
             android:configChanges="orientation|screenSize"
             android:theme="@style/AppTheme.NoActionBar"
-            android:launchMode="singleTop"
-            android:windowSoftInputMode="stateHidden"/>
+            android:launchMode="singleTop"/>
         <activity
             android:name=".ImportExportActivity"
             android:label="@string/importExportTitle"


### PR DESCRIPTION
Initially there was an issue where when one viewed
a budget or transaction (not to edit or add) the keyboard
would appear. To prevent the keyboard from blocking
the screen, the windowSoftInputMode was set to stayHidden,
which would prevent the keyboard from appearing until
something was selected. Removing this no longer results
in the keyboard appearing on the view screens. Perhaps
that behavior was a bug in older Android versions, or perhaps
the new layout does not cause the problem. Either way,
to improve the speed at which one can add a transaction,
the stayHidden setting is now being removed.

https://github.com/brarcher/budget-watch/issues/105