### PR TITLE
Search fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -14,8 +14,8 @@ android {
         applicationId "protect.budgetwatch"
         minSdkVersion 14
         targetSdkVersion 25
-        versionCode 17
-        versionName "0.15.1"
+        versionCode 18
+        versionName "0.15.2"
     }
     buildTypes {
         release {

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -35,3 +35,6 @@
 -keep class java.lang.ClassValue { *; }
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 -keep class org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement { *; }
+
+# For SearchView in appcompat
+-keep class android.support.v7.widget.SearchView { *; }


### PR DESCRIPTION
Without this rule, proguard removes the SerachView and
it cannot be found when the transactions view is shown.
This results in a NullPointerException.