### PR TITLE
Fixed content width for Spinner content

### DIFF
--- a/app/src/main/res/layout/spinner_textview.xml
+++ b/app/src/main/res/layout/spinner_textview.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <TextView xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="wrap_content"
+    android:layout_width="fill_parent"
     android:layout_height="wrap_content"
     android:textSize="20sp"
     android:padding="10sp"


### PR DESCRIPTION
"fill_parent" is a better width for a cell in a spinner, because with "fill_parent" you select a entry by touching a cell anywhere, not only on the text.