### PR TITLE
Round up all budget current values

### DIFF
--- a/app/src/main/java/protect/budgetwatch/DBHelper.java
+++ b/app/src/main/java/protect/budgetwatch/DBHelper.java
@@ -288,11 +288,12 @@ class DBHelper extends SQLiteOpenHelper
             {
                 String name = data.getString(data.getColumnIndexOrThrow(BudgetDbIds.NAME));
                 int max = data.getInt(data.getColumnIndexOrThrow(BudgetDbIds.MAX)) * totalMonthsInRange;
-                int expenses = data.getInt(data.getColumnIndexOrThrow(TOTAL_EXPENSE_COL));
-                int revenues = data.getInt(data.getColumnIndexOrThrow(TOTAL_REVENUE_COL));
-                int current = expenses - revenues;
+                double expenses = data.getDouble(data.getColumnIndexOrThrow(TOTAL_EXPENSE_COL));
+                double revenues = data.getDouble(data.getColumnIndexOrThrow(TOTAL_REVENUE_COL));
+                double current = expenses - revenues;
+                int currentRounded = (int)Math.ceil(current);
 
-                budgets.add(new Budget(name, max, current));
+                budgets.add(new Budget(name, max, currentRounded));
             } while(data.moveToNext());
         }
 

--- a/app/src/test/java/protect/budgetwatch/BudgetAdapterTest.java
+++ b/app/src/test/java/protect/budgetwatch/BudgetAdapterTest.java
@@ -49,7 +49,8 @@ public class BudgetAdapterTest
         DBHelper db = new DBHelper(activity);
         final String NAME = "name";
         final int BUDGET = 100;
-        final int CURRENT = 50;
+        final double CURRENT = 50.01;
+        final int CURRENT_CEIL = (int)Math.ceil(CURRENT);
 
         db.insertBudget(NAME, BUDGET);
         db.insertTransaction(DBHelper.TransactionDbIds.EXPENSE, "", "", NAME, CURRENT, "", nowMs, "");
@@ -67,11 +68,11 @@ public class BudgetAdapterTest
         final TextView budgetValue = (TextView) view.findViewById(R.id.budgetValue);
 
         assertEquals(NAME, budgetName.getText().toString());
-        assertEquals(CURRENT, budgetBar.getProgress());
+        assertEquals(CURRENT_CEIL, budgetBar.getProgress());
         assertEquals(SCALED_BUDGET, budgetBar.getMax());
 
         String fractionFormat = activity.getResources().getString(R.string.fraction);
-        String fraction = String.format(fractionFormat, CURRENT, SCALED_BUDGET);
+        String fraction = String.format(fractionFormat, CURRENT_CEIL, SCALED_BUDGET);
         assertEquals(fraction, budgetValue.getText().toString());
     }
 }


### PR DESCRIPTION
Up to now if the transactions for a budget had a cents value its was truncated. With this change, any
cents will be rounded to the next whole value. As an example, 1.01 becomes 2.

https://github.com/brarcher/budget-watch/issues/112