### PR TITLE
Migrate to Android Studio 3.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: true
 install:
 - echo y | android update sdk -u -a -t tools
 - echo y | android update sdk -u -a -t platform-tools
-- echo y | android update sdk -u -a -t build-tools-25.0.2
+- echo y | android update sdk -u -a -t build-tools-26.0.2
 - echo y | android update sdk -u -a -t android-25
 - echo y | android update sdk -u -a -t extra-google-m2repository
 - echo y | android update sdk -u -a -t extra-android-m2repository

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,6 @@ findbugs {
 
 android {
     compileSdkVersion 25
-    buildToolsVersion '25.0.2'
 
     defaultConfig {
         applicationId "protect.budgetwatch"
@@ -36,6 +35,14 @@ android {
       disable "InflateParams"
       disable "MissingTranslation"
    }
+
+    // Starting with Android Studio 3 Robolectric is unable to find resources.
+    // The following allows it to find the resources.
+    testOptions {
+        unitTests {
+            includeAndroidResources = true
+        }
+    }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -3,9 +3,12 @@
 buildscript {
     repositories {
         jcenter()
+
+        // For the Android Gradle plugin
+        google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,4 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
+#android.enableAapt2=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Mar 13 20:59:43 EDT 2017
+#Mon Dec 25 14:49:49 EST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip


### PR DESCRIPTION
Changes required for the migration:
- Android Gradle plugin no longer available in jcenter,
  but in its own repository: google()
- No longer need to specify the build tools used, as the
  Android Gradle plugin specifies which one to use.
  (Travis CI still needs it defined, and it is updated).
- Robolectric cannot find resources with the updated
  toolchain, and needs an additional configuration.
- New gradle version is used.