### PR TITLE
Remove file:// Uri from backup file picker

### DIFF
--- a/app/src/main/java/protect/budgetwatch/ImportExportActivity.java
+++ b/app/src/main/java/protect/budgetwatch/ImportExportActivity.java
@@ -113,7 +113,6 @@ public class ImportExportActivity extends AppCompatActivity
 
         // Check that there is an activity that can bring up a file chooser
         final Intent intentPickAction = new Intent(Intent.ACTION_PICK);
-        intentPickAction.setData(Uri.parse("file://"));
 
         Button importFilesystem = (Button) findViewById(R.id.importOptionFilesystemButton);
         importFilesystem.setOnClickListener(new View.OnClickListener()

--- a/app/src/test/java/protect/budgetwatch/ImportExportActivityTest.java
+++ b/app/src/test/java/protect/budgetwatch/ImportExportActivityTest.java
@@ -73,10 +73,6 @@ public class ImportExportActivityTest
         info.activityInfo.exported = true;
 
         Intent intent = new Intent(handler);
-        if(handler.equals(Intent.ACTION_PICK))
-        {
-            intent.setData(Uri.parse("file://"));
-        }
 
         if(handler.equals(Intent.ACTION_GET_CONTENT))
         {

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,4 +16,3 @@
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-#android.enableAapt2=false


### PR DESCRIPTION
On Android SDK 24+ exposing a file Uri causes a failure.
Picking a file from a file chooser using data of a file://
Uri also hits this. As this is not necessary, removing the
Uri.