### PR TITLE
Fix crash on some corruption when importing CSV

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:25.3.1'
     compile 'com.android.support:design:25.3.1'
-    compile 'org.apache.commons:commons-csv:1.2'
+    compile 'org.apache.commons:commons-csv:1.5'
     compile group: 'com.google.guava', name: 'guava', version: '20.0'
     compile 'com.github.apl-devs:appintro:v4.2.0'
     testCompile 'junit:junit:4.12'

--- a/app/src/main/java/protect/budgetwatch/CsvDatabaseImporter.java
+++ b/app/src/main/java/protect/budgetwatch/CsvDatabaseImporter.java
@@ -60,7 +60,7 @@ public class CsvDatabaseImporter implements DatabaseImporter
             // Closing the input stream is the responsibility of the caller.
             database.setTransactionSuccessful();
         }
-        catch(IllegalArgumentException e)
+        catch(IllegalArgumentException|IllegalStateException e)
         {
             throw new FormatException("Issue parsing CSV data", e);
         }

--- a/app/src/test/java/protect/budgetwatch/ImportExportTest.java
+++ b/app/src/test/java/protect/budgetwatch/ImportExportTest.java
@@ -307,7 +307,11 @@ public class ImportExportTest
 
             DatabaseTestHelper.clearDatabase(db, activity);
 
-            String corruptEntry = "ThisStringIsLikelyNotPartOfAnyFormat";
+            // commons-csv would throw a RuntimeException if an entry was quotes but had
+            // content after. For example:
+            //   abc,def,""abc,abc
+            //             ^ after the quote there should only be a , \n or EOF
+            String corruptEntry = "ThisStringIsLikelyNotPartOfAnyFormat,\"\"a";
 
             ByteArrayInputStream inData = new ByteArrayInputStream((outData.toString() + corruptEntry).getBytes());
 


### PR DESCRIPTION
Commons-CSV would throw a RuntimeException in some cases of
bad CSV input. This was later changed to throwing an
IllegalStateException. Updating to v1.5 to pick-up the change.