### PR TITLE
Move shortcut creation to launcher

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,7 +3,6 @@
     package="protect.budgetwatch">
 
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
-    <uses-permission android:name="com.android.launcher.permission.INSTALL_SHORTCUT" />
     <uses-permission android:name="android.permission.CAMERA"/>
     <uses-feature android:required="true" android:name="android.hardware.camera"/>
 
@@ -68,6 +67,15 @@
             android:name=".intro.IntroActivity"
             android:label=""
             android:theme="@style/AppTheme.NoActionBar"/>
+        <activity
+            android:name=".ShortcutConfigure"
+            android:label="@string/addShortcutsTitle"
+            android:configChanges="orientation|screenSize">
+            <intent-filter>
+                <action android:name="android.intent.action.CREATE_SHORTCUT"/>
+                <category android:name="android.intent.category.DEFAULT"/>
+            </intent-filter>
+        </activity>
         <receiver android:label="@string/app_name" android:name="TransactionExpenseWidget">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>

--- a/app/src/main/java/protect/budgetwatch/MainActivity.java
+++ b/app/src/main/java/protect/budgetwatch/MainActivity.java
@@ -182,51 +182,7 @@ public class MainActivity extends AppCompatActivity
             return true;
         }
 
-        if(id == R.id.action_shortcuts)
-        {
-            addShortcuts();
-            return true;
-        }
-
         return super.onOptionsItemSelected(item);
-    }
-
-    private void addShortcuts()
-    {
-        for(int transactionType : new int[]{DBHelper.TransactionDbIds.EXPENSE, DBHelper.TransactionDbIds.REVENUE})
-        {
-            Intent shortcutIntent = new Intent(this, TransactionViewActivity.class);
-            shortcutIntent.setAction(Intent.ACTION_MAIN);
-            // Prevent instances of the view activity from piling up; if one exists let this
-            // one replace it.
-            shortcutIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-            Bundle bundle = new Bundle();
-            bundle.putInt("type", transactionType);
-            shortcutIntent.putExtras(bundle);
-
-            Intent intent = new Intent();
-            intent.putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcutIntent);
-
-            String title;
-            if(transactionType == DBHelper.TransactionDbIds.EXPENSE)
-            {
-                title = getResources().getString(R.string.addExpenseTransactionTitle);
-            }
-            else
-            {
-                title = getResources().getString(R.string.addRevenueTransactionTitle);
-            }
-
-            intent.putExtra(Intent.EXTRA_SHORTCUT_NAME, title);
-            intent.putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, Intent.ShortcutIconResource
-                    .fromContext(this, R.mipmap.ic_launcher));
-            intent.setAction("com.android.launcher.action.INSTALL_SHORTCUT");
-            // Do not duplicate the shortcut if it is already there
-            intent.putExtra("duplicate", false);
-            getApplicationContext().sendBroadcast(intent);
-        }
-
-        Toast.makeText(this, R.string.shortcutsAdded, Toast.LENGTH_LONG).show();
     }
 
     private void displayAboutDialog()

--- a/app/src/main/java/protect/budgetwatch/ShortcutConfigure.java
+++ b/app/src/main/java/protect/budgetwatch/ShortcutConfigure.java
@@ -1,0 +1,151 @@
+package protect.budgetwatch;
+
+import android.content.Context;
+import android.content.Intent;
+import android.os.Bundle;
+import android.os.Parcelable;
+import android.support.v7.app.AppCompatActivity;
+import android.support.v7.widget.Toolbar;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import java.util.LinkedList;
+import java.util.List;
+
+public class ShortcutConfigure extends AppCompatActivity
+{
+    static final String TAG = "BudgetWatch";
+
+    static class ShortcutOption
+    {
+        String name;
+        Intent intent;
+    }
+
+    static class ShortcutAdapter extends ArrayAdapter<ShortcutOption>
+    {
+        ShortcutAdapter(Context context, List<ShortcutOption> items)
+        {
+            super(context, 0, items);
+        }
+
+        static class ViewHolder
+        {
+            TextView name;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent)
+        {
+            // Get the data item for this position
+            ShortcutOption item = getItem(position);
+
+            ShortcutAdapter.ViewHolder holder;
+
+            // Check if an existing view is being reused, otherwise inflate the view
+
+            if (convertView == null)
+            {
+                convertView = LayoutInflater.from(getContext()).inflate(R.layout.shortcut_option_layout,
+                        parent, false);
+
+                holder = new ShortcutAdapter.ViewHolder();
+                holder.name = (TextView) convertView.findViewById(R.id.name);
+                convertView.setTag(holder);
+            }
+            else
+            {
+                holder = (ShortcutAdapter.ViewHolder)convertView.getTag();
+            }
+
+            holder.name.setText(item.name);
+
+            return convertView;
+        }
+    }
+
+    private List<ShortcutOption> getPossibleShortcuts()
+    {
+        LinkedList<ShortcutOption> shortcuts = new LinkedList<>();
+
+        for(int transactionType : new int[]{DBHelper.TransactionDbIds.EXPENSE, DBHelper.TransactionDbIds.REVENUE})
+        {
+            Intent shortcutIntent = new Intent(this, TransactionViewActivity.class);
+            shortcutIntent.setAction(Intent.ACTION_MAIN);
+            // Prevent instances of the view activity from piling up; if one exists let this
+            // one replace it.
+            shortcutIntent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
+            Bundle bundle = new Bundle();
+            bundle.putInt("type", transactionType);
+            shortcutIntent.putExtras(bundle);
+
+            String title;
+            if(transactionType == DBHelper.TransactionDbIds.EXPENSE)
+            {
+                title = getResources().getString(R.string.addExpenseTransactionShortcutTitle);
+            }
+            else
+            {
+                title = getResources().getString(R.string.addRevenueTransactionShortcutTitle);
+            }
+
+            ShortcutOption shortcutOption = new ShortcutOption();
+            shortcutOption.name = title;
+            shortcutOption.intent = shortcutIntent;
+
+            shortcuts.add(shortcutOption);
+        }
+
+        return shortcuts;
+    }
+
+    @Override
+    public void onCreate(Bundle bundle)
+    {
+        super.onCreate(bundle);
+
+        // Set the result to CANCELED.  This will cause nothing to happen if the
+        // aback button is pressed.
+        setResult(RESULT_CANCELED);
+
+        setContentView(R.layout.main_activity);
+        Toolbar toolbar = (Toolbar) findViewById(R.id.toolbar);
+        toolbar.setVisibility(View.GONE);
+
+        final ListView shortcutList = (ListView) findViewById(R.id.list);
+        shortcutList.setVisibility(View.VISIBLE);
+
+        final ShortcutAdapter adapter = new ShortcutAdapter(this, getPossibleShortcuts());
+        shortcutList.setAdapter(adapter);
+
+        shortcutList.setOnItemClickListener(new AdapterView.OnItemClickListener()
+        {
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id)
+            {
+                ShortcutOption shortcut = (ShortcutOption)parent.getItemAtPosition(position);
+                if(shortcut == null)
+                {
+                    Log.w(TAG, "Clicked shortcut at position " + position + " is null");
+                    return;
+                }
+
+                Parcelable icon = Intent.ShortcutIconResource.fromContext(ShortcutConfigure.this, R.mipmap.ic_launcher);
+                Intent intent = new Intent();
+                intent.putExtra(Intent.EXTRA_SHORTCUT_INTENT, shortcut.intent);
+                intent.putExtra(Intent.EXTRA_SHORTCUT_NAME, shortcut.name);
+                intent.putExtra(Intent.EXTRA_SHORTCUT_ICON_RESOURCE, icon);
+                setResult(RESULT_OK, intent);
+
+                finish();
+            }
+        });
+    }
+}
+

--- a/app/src/main/res/layout/shortcut_option_layout.xml
+++ b/app/src/main/res/layout/shortcut_option_layout.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout android:orientation="vertical"
+              android:padding="10.0dp"
+              android:layout_width="fill_parent"
+              android:layout_height="fill_parent"
+              xmlns:android="http://schemas.android.com/apk/res/android">
+    <LinearLayout android:orientation="horizontal"
+                  android:padding="5.0dp"
+                  android:layout_width="fill_parent"
+                  android:layout_height="wrap_content"
+                  android:baselineAligned="true">
+        <TextView android:textSize="20.0sp"
+                  android:id="@+id/name"
+                  android:layout_width="0dp"
+                  android:layout_height="wrap_content"
+                  android:layout_weight="1.0"
+                  android:maxLines="1"/>
+    </LinearLayout>
+</LinearLayout>

--- a/app/src/main/res/menu/main_menu.xml
+++ b/app/src/main/res/menu/main_menu.xml
@@ -13,10 +13,6 @@
         android:title="@string/importExport"
         app:showAsAction="ifRoom"/>
     <item
-        android:id="@+id/action_shortcuts"
-        android:title="@string/addShortcuts"
-        app:showAsAction="never"/>
-    <item
         android:id="@+id/action_intro"
         android:title="@string/startIntro"
         app:showAsAction="never"/>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -18,6 +18,9 @@
     <string name="viewRevenueTransactionTitle">View Revenue</string>
     <string name="importExportTitle">Import/Export</string>
     <string name="totalBudgetTitle">Total</string>
+    <string name="addShortcutsTitle">Add Budget Watch Shortcut</string>
+    <string name="addExpenseTransactionShortcutTitle">Add Expense Shortcut</string>
+    <string name="addRevenueTransactionShortcutTitle">Add Revenue Shortcut</string>
 
     <string name="add">Add</string>
     <string name="selectDates">Select Dates</string>


### PR DESCRIPTION
Previously Budget Watch would create shortcuts
itself. To remove that permission from the app,
an activity is now added which handles the
CREATE_SHORTCUT action. With this, Budget Watch
can be requested to give details on a shortcut to
create and the launcher will take care of creating it.