### PR TITLE
Add support for exporting specific date ranges

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -54,6 +54,7 @@ dependencies {
     compile 'com.github.apl-devs:appintro:v4.2.0'
     testCompile 'junit:junit:4.12'
     testCompile "org.robolectric:robolectric:3.4.2"
+    testCompile group: 'org.javatuples', name: 'javatuples', version: '1.2'
 }
 
 task findbugs(type: FindBugs, dependsOn: 'assembleDebug') {

--- a/app/src/main/java/protect/budgetwatch/CsvDatabaseExporter.java
+++ b/app/src/main/java/protect/budgetwatch/CsvDatabaseExporter.java
@@ -13,6 +13,9 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.text.DateFormat;
+import java.util.Date;
+import java.util.Locale;
 
 /**
  * Class for exporting the database into CSV (Comma Separate Values)
@@ -20,6 +23,8 @@ import java.io.OutputStreamWriter;
  */
 public class CsvDatabaseExporter implements DatabaseExporter
 {
+    private static final String DATE_FORMATTED_FIELD = "date_formatted";
+
     public void exportData(Context context, DBHelper db, OutputStream outStream, ImportExportProgressUpdater updater) throws IOException, InterruptedException
     {
         OutputStreamWriter stream = new OutputStreamWriter(outStream, Charsets.UTF_8);
@@ -37,6 +42,7 @@ public class CsvDatabaseExporter implements DatabaseExporter
                     DBHelper.TransactionDbIds.VALUE,
                     DBHelper.TransactionDbIds.NOTE,
                     DBHelper.TransactionDbIds.DATE,
+                    DATE_FORMATTED_FIELD,
                     DBHelper.TransactionDbIds.RECEIPT);
 
             for (Cursor cursor : new Cursor[]{db.getExpenses(), db.getRevenues()})
@@ -52,6 +58,12 @@ public class CsvDatabaseExporter implements DatabaseExporter
                         receiptFilename = receiptFile.getName();
                     }
 
+                    Locale currentLocale = Locale.getDefault();
+                    DateFormat dateFormat = DateFormat.getDateTimeInstance(
+                            DateFormat.DEFAULT, DateFormat.DEFAULT, currentLocale);
+
+                    String dateFormatted = dateFormat.format(new Date(transaction.dateMs));
+
                     printer.printRecord(transaction.id,
                             transaction.type == DBHelper.TransactionDbIds.EXPENSE ?
                                     "EXPENSE" : "REVENUE",
@@ -61,6 +73,7 @@ public class CsvDatabaseExporter implements DatabaseExporter
                             transaction.value,
                             transaction.note,
                             transaction.dateMs,
+                            dateFormatted,
                             receiptFilename);
 
                     updater.update();
@@ -87,6 +100,7 @@ public class CsvDatabaseExporter implements DatabaseExporter
                         budget.max,
                         "", // blank note
                         "", // blank date
+                        "", // blank formatted date
                         ""); // blank receipt
 
                 updater.update();

--- a/app/src/main/java/protect/budgetwatch/DBHelper.java
+++ b/app/src/main/java/protect/budgetwatch/DBHelper.java
@@ -614,7 +614,7 @@ class DBHelper extends SQLiteOpenHelper
      *      if not null, all returned expenses will have at least one field
      *      which contains this query string
      */
-    public Cursor getTransactions(int type, String budget, String search)
+    public Cursor getTransactions(int type, String budget, String search, Long startDateMs, Long endDateMs)
     {
         SQLiteDatabase db = getReadableDatabase();
 
@@ -649,6 +649,14 @@ class DBHelper extends SQLiteOpenHelper
             query += " )";
         }
 
+        if(startDateMs != null && endDateMs != null)
+        {
+            query += " AND " + TransactionDbIds.DATE + " >= ? AND " +
+                    TransactionDbIds.DATE + " <= ?";
+            args.addLast(Long.toString(startDateMs));
+            args.addLast(Long.toString(endDateMs));
+        }
+
         query += " ORDER BY " + TransactionDbIds.DATE + " DESC";
 
         String [] argArray = args.toArray(new String[args.size()]);
@@ -663,7 +671,7 @@ class DBHelper extends SQLiteOpenHelper
      */
     public Cursor getExpenses()
     {
-        return getTransactions(TransactionDbIds.EXPENSE, null, null);
+        return getTransactions(TransactionDbIds.EXPENSE, null, null, null, null);
     }
 
     /**
@@ -672,7 +680,7 @@ class DBHelper extends SQLiteOpenHelper
      */
     public Cursor getRevenues()
     {
-        return getTransactions(TransactionDbIds.REVENUE, null, null);
+        return getTransactions(TransactionDbIds.REVENUE, null, null, null, null);
     }
 
     /**

--- a/app/src/main/java/protect/budgetwatch/DatabaseExporter.java
+++ b/app/src/main/java/protect/budgetwatch/DatabaseExporter.java
@@ -14,5 +14,5 @@ interface DatabaseExporter
      * Export the database to the output stream in a given format.
      * @throws IOException
      */
-    void exportData(Context context, DBHelper db, OutputStream output, ImportExportProgressUpdater updater) throws IOException, InterruptedException;
+    void exportData(Context context, DBHelper db, Long startTimeMs, Long endTimeMs, OutputStream output, ImportExportProgressUpdater updater) throws IOException, InterruptedException;
 }

--- a/app/src/main/java/protect/budgetwatch/ImportExportProgressUpdater.java
+++ b/app/src/main/java/protect/budgetwatch/ImportExportProgressUpdater.java
@@ -14,21 +14,21 @@ class ImportExportProgressUpdater
     private final Activity activity;
     private final ProgressDialog dialog;
     private final String baseMessage;
-    private final Integer totalEntries;
 
+    private Integer totalEntries;
     private int entriesMoved = 0;
     private long lastUpdateTimeMs = 0;
 
     ImportExportProgressUpdater(Activity activity, ProgressDialog dialog, String baseMessage)
     {
-        this(activity, dialog, baseMessage, null);
-    }
-
-    ImportExportProgressUpdater(Activity activity, ProgressDialog dialog, String baseMessage, Integer totalEntries)
-    {
         this.activity = activity;
         this.dialog = dialog;
         this.baseMessage = baseMessage;
+        this.totalEntries = null;
+    }
+
+    public void setTotal(int totalEntries)
+    {
         this.totalEntries = totalEntries;
     }
 

--- a/app/src/main/java/protect/budgetwatch/MultiFormatExporter.java
+++ b/app/src/main/java/protect/budgetwatch/MultiFormatExporter.java
@@ -20,7 +20,7 @@ class MultiFormatExporter
      * false otherwise. If false, partial data may have been
      * written to the output stream, and it should be discarded.
      */
-    public static boolean exportData(Context context, DBHelper db, OutputStream output, DataFormat format, ImportExportProgressUpdater updater)
+    public static boolean exportData(Context context, DBHelper db, Long startTimeMs, Long endTimeMs, OutputStream output, DataFormat format, ImportExportProgressUpdater updater)
     {
         DatabaseExporter exporter = null;
 
@@ -41,7 +41,7 @@ class MultiFormatExporter
         {
             try
             {
-                exporter.exportData(context, db, output, updater);
+                exporter.exportData(context, db, startTimeMs, endTimeMs, output, updater);
                 return true;
             }
             catch(IOException | InterruptedException e)

--- a/app/src/main/java/protect/budgetwatch/TransactionFragment.java
+++ b/app/src/main/java/protect/budgetwatch/TransactionFragment.java
@@ -48,7 +48,7 @@ public class TransactionFragment extends Fragment
         ListView listView = (ListView) layout.findViewById(R.id.list);
         final TextView helpText = (TextView) layout.findViewById(R.id.helpText);
 
-        Cursor cursor = _db.getTransactions(_transactionType, budgetToDisplay, searchToUse);
+        Cursor cursor = _db.getTransactions(_transactionType, budgetToDisplay, searchToUse, null, null);
 
         if(cursor.getCount() > 0)
         {

--- a/app/src/main/java/protect/budgetwatch/ZipDatabaseExporter.java
+++ b/app/src/main/java/protect/budgetwatch/ZipDatabaseExporter.java
@@ -15,7 +15,7 @@ import java.util.zip.ZipOutputStream;
  */
 public class ZipDatabaseExporter implements DatabaseExporter
 {
-    public void exportData(Context context, DBHelper db, OutputStream outStream, ImportExportProgressUpdater updater) throws IOException, InterruptedException
+    public void exportData(Context context, DBHelper db, Long startTimeMs, Long endTimeMs, OutputStream outStream, ImportExportProgressUpdater updater) throws IOException, InterruptedException
     {
         ZipOutputStream out = new ZipOutputStream(outStream);
 
@@ -52,6 +52,6 @@ public class ZipDatabaseExporter implements DatabaseExporter
         // Write the database to the zip file as a CSV file
         ZipEntry databaseEntry = new ZipEntry("database.csv");
         out.putNextEntry(databaseEntry);
-        MultiFormatExporter.exportData(context, db, out, DataFormat.CSV, updater);
+        MultiFormatExporter.exportData(context, db, startTimeMs, endTimeMs, out, DataFormat.CSV, updater);
     }
 }

--- a/app/src/main/res/layout/import_export_activity.xml
+++ b/app/src/main/res/layout/import_export_activity.xml
@@ -87,6 +87,38 @@
                     android:drawSelectorOnTop="true" />
             </LinearLayout>
 
+            <LinearLayout
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:orientation="horizontal">
+                <TextView
+                    android:textSize="@dimen/text_size_medium"
+                    android:layout_gravity="start"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:labelFor="@+id/exportFileFormatSpinner"
+                    android:text="@string/dateRangeField" />
+
+                <TextView
+                    android:id="@+id/dateRangeText"
+                    android:textSize="@dimen/text_size_medium"
+                    android:layout_gravity="start"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:labelFor="@+id/exportFileFormatSpinner"
+                    android:layout_marginStart="10dp"
+                    android:layout_marginLeft="10dp"
+                    android:text="@string/allDates" />
+            </LinearLayout>
+
+            <Button
+                android:id="@+id/dateRangeSelectButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="start"
+                android:paddingBottom="10dp"
+                android:text="@string/changeDateRange" />
+
             <Button
                 android:id="@+id/exportButton"
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -78,6 +78,10 @@
 
     <string name="importExport">Import/Export</string>
     <string name="exportName">Export</string>
+    <string name="dateRangeField">Date Range:</string>
+    <string name="allDates">All Dates</string>
+    <string name="changeDateRange">Change date range</string>
+    <string name="exportDateRangeHelp">Select date range of transactions to export</string>
     <string name="importedFrom">Imported from: %1$s</string>
     <string name="fileFormat">File format</string>
     <string name="exportedTo">Exported to: %1$s</string>


### PR DESCRIPTION
As a part of this change, exporters themselves must declare how many entries they are exporting to the ImportExportProgressUpdater, as it is at that level that the transactions to be exported are selected.

https://github.com/brarcher/budget-watch/issues/145